### PR TITLE
Update vegas version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Like for big data frameworks, support for plotting libraries can be added on-the
 
 Use like
 ```scala
-import $ivy.`org.vegas-viz::vegas:0.3.8`
+import $ivy.`org.vegas-viz::vegas:0.3.11`
 
 import vegas._
 


### PR DESCRIPTION
Prior to `0.3.11` the javascript output from Vegas was using an expected jQuery interface. The `0.3.11` release makes use of plain javascript to do iframe resizing. This mostly matters for nteract frontends and jupyterlab, which don't provide jquery as a global. Since this was a canonical example in the README, I figured I should bring it up to date. 😄 