### PR TITLE
Fix some warnings

### DIFF
--- a/modules/scala/scala-kernel-api/src/main/scala/almond/api/Properties.scala
+++ b/modules/scala/scala-kernel-api/src/main/scala/almond/api/Properties.scala
@@ -1,12 +1,12 @@
 package almond.api
 
-import java.util.Properties
+import java.util.{Properties => JProperties}
 
 object Properties {
 
   private lazy val props = {
 
-    val p = new Properties
+    val p = new JProperties
 
     try {
       p.load(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -30,8 +30,8 @@ object Settings {
   )
 
   lazy val dontPublish = Seq(
-    publish := (),
-    publishLocal := (),
+    publish := {},
+    publishLocal := {},
     publishArtifact := false
   )
 


### PR DESCRIPTION
This PR fixes the two following warnings.

- `Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.` ([L498](https://travis-ci.org/almond-sh/almond/jobs/446653471#L498))
- `imported `Properties' is permanently hidden by definition of object Properties in package api` ([L550](https://travis-ci.org/almond-sh/almond/jobs/446653471#L550))