### PR TITLE
Tweak snapshot version handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,11 +15,20 @@ inThisBuild(List(
   ),
   version := {
     // Simple X.Y.Z-SNAPSHOT versions are easier to find once published locally
+    val forceSimpleVersion = sys.env
+      .get("FORCE_SIMPLE_VERSION")
+      .contains("1")
     val onTravisCi = sys.env.exists(_._1.startsWith("TRAVIS_"))
     val v = version.value
-    if (!onTravisCi && v.contains("+") && v.endsWith("-SNAPSHOT"))
-      v.takeWhile(_ != '+') + "-SNAPSHOT"
-    else
+    if ((forceSimpleVersion || !onTravisCi) && v.contains("+") && v.endsWith("-SNAPSHOT")) {
+      val base = v.takeWhile(_ != '+')
+      val elems = base.split('.')
+      val last = scala.util.Try(elems.last.toInt)
+        .toOption
+	.fold(elems.last)(n => (n + 1).toString)
+      val bumpedBase = (elems.init :+ last).mkString(".")
+      bumpedBase + "-SNAPSHOT"
+    } else
       v
   }
 ))

--- a/scripts/update-website.sh
+++ b/scripts/update-website.sh
@@ -7,6 +7,8 @@ if [ "$TRAVIS_BRANCH" != "" ]; then
   source scripts/setup-sbt-extra.sh
 fi
 
+export FORCE_SIMPLE_VERSION=1
+
 sbt \
   interpreter-api/exportVersions \
   interpreter-api/publishLocal \


### PR DESCRIPTION
Locally, when checking out sources, this makes the version be e.g. `0.1.11-SNAPSHOT` if the latest release is `0.1.10`. This is also used when generating / pushing the website.