### PR TITLE
Add basic support for displaying images

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -579,7 +579,7 @@ object ScalaInterpreter {
       |}
       |import almond.api.JupyterAPIHolder.value.publish.display
       |import almond.interpreter.api.DisplayData.DisplayDataSyntax
-      |import almond.api.helpers.Display.{html, js, text}
+      |import almond.api.helpers.Display.{html, js, text, jpg, png, svg}
     """.stripMargin
 
   private def error(colors: Colors, exOpt: Option[Throwable], msg: String) =

--- a/modules/scala/scala-kernel-api/src/main/scala/almond/api/helpers/Display.scala
+++ b/modules/scala/scala-kernel-api/src/main/scala/almond/api/helpers/Display.scala
@@ -43,4 +43,31 @@ object Display {
       DisplayData.js(content)
     )
 
+  def jpg(content: Array[Byte])(implicit outputHandler: OutputHandler): Display = {
+    val id = newId()
+    outputHandler.display(
+      DisplayData.jpg(content)
+        .withId(id)
+    )
+    new Display(id, DisplayData.ContentType.jpg)
+  }
+
+  def png(content: Array[Byte])(implicit outputHandler: OutputHandler): Display = {
+    val id = newId()
+    outputHandler.display(
+      DisplayData.png(content)
+        .withId(id)
+    )
+    new Display(id, DisplayData.ContentType.png)
+  }
+
+  def svg(content: String)(implicit outputHandler: OutputHandler): Display = {
+    val id = newId()
+    outputHandler.display(
+      DisplayData.svg(content)
+        .withId(id)
+    )
+    new Display(id, DisplayData.ContentType.svg)
+  }
+
 }

--- a/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/DisplayData.scala
+++ b/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/DisplayData.scala
@@ -1,5 +1,7 @@
 package almond.interpreter.api
 
+import java.util.Base64
+
 /** Data that can be pushed to and displayed in the Jupyter UI */
 final case class DisplayData(
   data: Map[String, String],
@@ -24,6 +26,9 @@ object DisplayData {
     def markdown = "text/markdown"
     def html = "text/html"
     def js = "application/javascript"
+    def jpg = "image/jpeg"
+    def png = "image/png"
+    def svg = "image/svg+xml"
   }
 
   def text(text: String): DisplayData =
@@ -34,6 +39,12 @@ object DisplayData {
     DisplayData(Map(ContentType.html -> content))
   def js(content: String): DisplayData =
     DisplayData(Map(ContentType.js -> content))
+  def jpg(content: Array[Byte]): DisplayData =
+    DisplayData(Map(ContentType.jpg -> Base64.getEncoder.encodeToString(content)))
+  def png(content: Array[Byte]): DisplayData =
+    DisplayData(Map(ContentType.png -> Base64.getEncoder.encodeToString(content)))
+  def svg(content: String): DisplayData =
+    DisplayData(Map(ContentType.svg -> content))
 
   val empty: DisplayData =
     DisplayData(Map.empty)


### PR DESCRIPTION
@alexarchambault As discussed this could be generalized and extended in a followup PR to be similar to [IPython.display](
https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html). But in a more typesafe way.