### PR TITLE
Add support for displaying images from a file or from a URL

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -579,7 +579,7 @@ object ScalaInterpreter {
       |}
       |import almond.api.JupyterAPIHolder.value.publish.display
       |import almond.interpreter.api.DisplayData.DisplayDataSyntax
-      |import almond.api.helpers.Display.{html, js, text, jpg, png, svg}
+      |import almond.api.helpers.Display.{html, js, text, svg, Image}
     """.stripMargin
 
   private def error(colors: Colors, exOpt: Option[Throwable], msg: String) =

--- a/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/DisplayData.scala
+++ b/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/DisplayData.scala
@@ -28,6 +28,7 @@ object DisplayData {
     def js = "application/javascript"
     def jpg = "image/jpeg"
     def png = "image/png"
+    def gif = "image/gif"
     def svg = "image/svg+xml"
   }
 


### PR DESCRIPTION
Extends on #255 to allow displaying images from local files or URLs (embedded or linked).

Example usage:
```Scala
val url = "https://scala-lang.org/resources/img/frontpage/scala-spiral.png"
Image.fromUrl(url, width=Some("100px"), embed=true)
```

 I think there's still potential to make this more generic in the future. Perhaps even a type class based approach that allows users to encode objects into the different mime types supported by the frontend.