### PR TITLE
Update to sbt 1.2.7 to get rid of sbt/sbt#4441

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.7


### PR DESCRIPTION
I'm running into the `Different extra API hashes` issue sbt/sbt#4441. Fortunately this has been fixed in sbt 1.2.7.