### PR TITLE
Recognize exit keyword in jupyter-console (#240)

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -575,7 +575,7 @@ final class ScalaInterpreter(
         ExecuteResult.Success()
 
       case Res.Exit(_) =>
-        ???
+        ExecuteResult.Exit
     }
   }
 

--- a/modules/shared/interpreter/src/main/scala/almond/interpreter/ExecuteResult.scala
+++ b/modules/shared/interpreter/src/main/scala/almond/interpreter/ExecuteResult.scala
@@ -49,4 +49,9 @@ object ExecuteResult {
     */
   case object Abort extends ExecuteResult(success = false)
 
+
+  /**
+    * [[ExecuteResult]], if execution was exited
+    */
+  case object Exit extends ExecuteResult(success = true)
 }

--- a/modules/shared/protocol/src/main/scala/almond/protocol/Execute.scala
+++ b/modules/shared/protocol/src/main/scala/almond/protocol/Execute.scala
@@ -25,7 +25,7 @@ object Execute {
       execution_count: Int,
       user_expressions: Map[String, Json],
       status: String, // no default value here for the value not to be swallowed by the JSON encoder
-      payload: List[Json],
+      payload: List[Json]
     ) extends Reply {
       assert(status == "ok")
     }
@@ -40,7 +40,7 @@ object Execute {
           execution_count,
           user_expressions,
           "ok",
-          payload,
+          payload
         )
     }
 

--- a/modules/shared/protocol/src/main/scala/almond/protocol/Execute.scala
+++ b/modules/shared/protocol/src/main/scala/almond/protocol/Execute.scala
@@ -15,6 +15,7 @@ object Execute {
     stop_on_error: Option[Boolean] = None
   )
 
+
   sealed abstract class Reply extends Product with Serializable
 
   object Reply {
@@ -23,7 +24,8 @@ object Execute {
     final case class Success private (
       execution_count: Int,
       user_expressions: Map[String, Json],
-      status: String // no default value here for the value not to be swallowed by the JSON encoder
+      status: String, // no default value here for the value not to be swallowed by the JSON encoder
+      payload: List[Json],
     ) extends Reply {
       assert(status == "ok")
     }
@@ -31,12 +33,14 @@ object Execute {
     object Success {
       def apply(
         execution_count: Int,
-        user_expressions: Map[String, Json] // value type?
+        user_expressions: Map[String, Json], // value type?
+        payload: List[Json] = List[Json]()
       ): Success =
         Success(
           execution_count,
           user_expressions,
-          "ok"
+          "ok",
+          payload,
         )
     }
 


### PR DESCRIPTION
As described in #240  typing "exit" in jupyter-console while using the `almond` kernel wouldn't shutdown the kernel. 

This PR solves that issue.