### PR TITLE
Display latex & markdown

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -772,7 +772,7 @@ object ScalaInterpreter {
       |}
       |import almond.api.JupyterAPIHolder.value.publish.display
       |import almond.interpreter.api.DisplayData.DisplayDataSyntax
-      |import almond.api.helpers.Display.{html, js, text, svg, Image}
+      |import almond.api.helpers.Display.{html, js, latex, text, svg, Image}
     """.stripMargin
 
   private def error(colors: Colors, exOpt: Option[Throwable], msg: String) =

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -772,7 +772,7 @@ object ScalaInterpreter {
       |}
       |import almond.api.JupyterAPIHolder.value.publish.display
       |import almond.interpreter.api.DisplayData.DisplayDataSyntax
-      |import almond.api.helpers.Display.{html, js, latex, text, svg, Image}
+      |import almond.api.helpers.Display.{html, js, latex, markdown, text, svg, Image}
     """.stripMargin
 
   private def error(colors: Colors, exOpt: Option[Throwable], msg: String) =

--- a/modules/scala/scala-kernel-api/src/main/scala/almond/api/helpers/Display.scala
+++ b/modules/scala/scala-kernel-api/src/main/scala/almond/api/helpers/Display.scala
@@ -24,6 +24,15 @@ object Display {
   private def newId(): String =
     UUID.randomUUID().toString
 
+  def markdown(content: String)(implicit outputHandler: OutputHandler): Display = {
+    val id = newId()
+    outputHandler.display(
+      DisplayData.markdown(content)
+        .withId(id)
+    )
+    new Display(id, DisplayData.ContentType.markdown)
+  }
+
   def html(content: String)(implicit outputHandler: OutputHandler): Display = {
     val id = newId()
     outputHandler.display(

--- a/modules/scala/scala-kernel-api/src/main/scala/almond/api/helpers/Display.scala
+++ b/modules/scala/scala-kernel-api/src/main/scala/almond/api/helpers/Display.scala
@@ -33,6 +33,15 @@ object Display {
     new Display(id, DisplayData.ContentType.html)
   }
 
+  def latex(content: String)(implicit outputHandler: OutputHandler): Display = {
+    val id = newId()
+    outputHandler.display(
+      DisplayData.latex(content)
+        .withId(id)
+    )
+    new Display(id, DisplayData.ContentType.latex)
+  }
+
   def text(content: String)(implicit outputHandler: OutputHandler): Display = {
     val id = newId()
     outputHandler.display(

--- a/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/DisplayData.scala
+++ b/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/DisplayData.scala
@@ -58,6 +58,8 @@ object DisplayData {
       DisplayData(Map(ContentType.text -> s))
     def as(mimeType: String): DisplayData =
       DisplayData(Map(mimeType -> s))
+    def asMarkdown: DisplayData =
+      DisplayData(Map(ContentType.markdown -> s))
     def asHtml: DisplayData =
       DisplayData(Map(ContentType.html -> s))
     def asLatex: DisplayData =

--- a/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/DisplayData.scala
+++ b/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/DisplayData.scala
@@ -25,6 +25,7 @@ object DisplayData {
     def text = "text/plain"
     def markdown = "text/markdown"
     def html = "text/html"
+    def latex = "text/latex"
     def js = "application/javascript"
     def jpg = "image/jpeg"
     def png = "image/png"
@@ -38,6 +39,8 @@ object DisplayData {
     DisplayData(Map(ContentType.markdown -> content))
   def html(content: String): DisplayData =
     DisplayData(Map(ContentType.html -> content))
+  def latex(content: String): DisplayData =
+    DisplayData(Map(ContentType.latex -> content))
   def js(content: String): DisplayData =
     DisplayData(Map(ContentType.js -> content))
   def jpg(content: Array[Byte]): DisplayData =
@@ -57,6 +60,8 @@ object DisplayData {
       DisplayData(Map(mimeType -> s))
     def asHtml: DisplayData =
       DisplayData(Map(ContentType.html -> s))
+    def asLatex: DisplayData =
+      DisplayData(Map(ContentType.latex -> s))
     def asJs: DisplayData =
       DisplayData(Map(ContentType.js -> s))
   }


### PR DESCRIPTION
As discussed @ Scala Spree, these are shortcuts to produce LaTeX and Markdown content from a code cell. The resulting rich text widgets can be updated programatically as well.

This is what you get:
![capture d ecran de 2018-12-15 15-18-29](https://user-images.githubusercontent.com/15657735/50043940-0ec1ba80-007d-11e9-9ccd-2f2e21bab1e1.png)
