### PR TITLE
Allow to trap what user code sends to stdout / stderr

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -51,7 +51,8 @@ final class ScalaInterpreter(
   metabrowse: Boolean = false,
   metabrowseHost: String = "localhost",
   metabrowsePort: Int = -1,
-  lazyInit: Boolean = false
+  lazyInit: Boolean = false,
+  trapOutput: Boolean = false
 ) extends Interpreter { scalaInterp =>
 
   private val log = logCtx(getClass)
@@ -161,7 +162,12 @@ final class ScalaInterpreter(
       }
     }
   )
-  private val capture = new Capture
+
+  private val capture =
+    if (trapOutput)
+      Capture.nop()
+    else
+      Capture.create()
 
   private var commHandlerOpt = Option.empty[CommHandler]
 

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -455,7 +455,7 @@ final class ScalaInterpreter(
       case None =>
         log.warn("Interrupt asked, but no execution is running")
       case Some(t) =>
-        log.debug(s"Interrupt asked, stopping thread $t")
+        log.debug(s"Interrupt asked, stopping thread $t\n${t.getStackTrace.map("  " + _).mkString("\n")}")
         t.stop()
     }
   }
@@ -469,8 +469,8 @@ final class ScalaInterpreter(
           case None =>
             log.warn("Received SIGINT, but no execution is running")
           case Some(t) =>
-            log.debug(s"Received SIGINT, stopping thread $t")
             interruptedStackTraceOpt = Some(t.getStackTrace)
+            log.debug(s"Received SIGINT, stopping thread $t\n${interruptedStackTraceOpt.map("  " + _).mkString("\n")}")
             t.stop()
         }
       }.apply {

--- a/modules/scala/scala-interpreter/src/main/scala/almond/internals/Capture.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/internals/Capture.scala
@@ -1,65 +1,17 @@
 package almond.internals
 
 import java.io.PrintStream
-import java.nio.charset.{Charset, StandardCharsets}
 
-final class Capture(
-  inputBufferSize: Int = 1024,
-  outputBufferSize: Int = 1024,
-  internalCharset: Charset = StandardCharsets.UTF_8
-) {
+trait Capture {
+  def out: PrintStream
+  def err: PrintStream
 
-  // not thread-safe
+  def apply[T](stdout: String => Unit, stderr: String => Unit)(block: => T): T
+}
 
-  private var out0: String => Unit = _
-  private var err0: String => Unit = _
-
-  val out: PrintStream =
-    new FunctionOutputStream(
-      inputBufferSize,
-      outputBufferSize,
-      internalCharset,
-      s => if (out0 != null) out0(s)
-    ).printStream()
-
-  val err: PrintStream =
-    new FunctionOutputStream(
-      inputBufferSize,
-      outputBufferSize,
-      internalCharset,
-      s => if (err0 != null) err0(s)
-    ).printStream()
-
-
-  def apply[T](
-    stdout: String => Unit,
-    stderr: String => Unit
-  )(
-    block: => T
-  ): T =
-    try {
-      out0 = stdout
-      err0 = stderr
-
-      Console.withOut(out) {
-        Console.withErr(err) {
-          val oldOut = System.out
-          val oldErr = System.err
-
-          try {
-            System.setOut(out)
-            System.setErr(err)
-
-            block
-          } finally {
-            System.setOut(oldOut)
-            System.setErr(oldErr)
-          }
-        }
-      }
-    } finally {
-      out0 = null
-      err0 = null
-    }
-
+object Capture {
+  def create(): Capture =
+    new CaptureImpl
+  def nop(): Capture =
+    new NopCapture
 }

--- a/modules/scala/scala-interpreter/src/main/scala/almond/internals/CaptureImpl.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/internals/CaptureImpl.scala
@@ -1,0 +1,65 @@
+package almond.internals
+
+import java.io.PrintStream
+import java.nio.charset.{Charset, StandardCharsets}
+
+final class CaptureImpl(
+  inputBufferSize: Int = 1024,
+  outputBufferSize: Int = 1024,
+  internalCharset: Charset = StandardCharsets.UTF_8
+) extends Capture {
+
+  // not thread-safe
+
+  private var out0: String => Unit = _
+  private var err0: String => Unit = _
+
+  val out: PrintStream =
+    new FunctionOutputStream(
+      inputBufferSize,
+      outputBufferSize,
+      internalCharset,
+      s => if (out0 != null) out0(s)
+    ).printStream()
+
+  val err: PrintStream =
+    new FunctionOutputStream(
+      inputBufferSize,
+      outputBufferSize,
+      internalCharset,
+      s => if (err0 != null) err0(s)
+    ).printStream()
+
+
+  def apply[T](
+    stdout: String => Unit,
+    stderr: String => Unit
+  )(
+    block: => T
+  ): T =
+    try {
+      out0 = stdout
+      err0 = stderr
+
+      Console.withOut(out) {
+        Console.withErr(err) {
+          val oldOut = System.out
+          val oldErr = System.err
+
+          try {
+            System.setOut(out)
+            System.setErr(err)
+
+            block
+          } finally {
+            System.setOut(oldOut)
+            System.setErr(oldErr)
+          }
+        }
+      }
+    } finally {
+      out0 = null
+      err0 = null
+    }
+
+}

--- a/modules/scala/scala-interpreter/src/main/scala/almond/internals/NopCapture.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/internals/NopCapture.scala
@@ -1,0 +1,28 @@
+package almond.internals
+
+import java.io.PrintStream
+
+final class NopCapture extends Capture {
+  val out: PrintStream =
+    new NopOutputStream().printStream()
+  val err: PrintStream =
+    new NopOutputStream().printStream()
+
+  def apply[T](stdout: String => Unit, stderr: String => Unit)(block: => T): T =
+    Console.withOut(out) {
+      Console.withErr(err) {
+        val oldOut = System.out
+        val oldErr = System.err
+
+        try {
+          System.setOut(out)
+          System.setErr(err)
+
+          block
+        } finally {
+          System.setOut(oldOut)
+          System.setErr(oldErr)
+        }
+      }
+    }
+}

--- a/modules/scala/scala-interpreter/src/main/scala/almond/internals/NopOutputStream.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/internals/NopOutputStream.scala
@@ -1,0 +1,16 @@
+package almond.internals
+
+import java.io.{OutputStream, PrintStream}
+
+final class NopOutputStream extends OutputStream {
+
+  def write(b: Int): Unit =
+    ()
+
+  override def write(b: Array[Byte], off: Int, len: Int) =
+    ()
+
+  def printStream(): PrintStream =
+    new PrintStream(this)
+
+}

--- a/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
@@ -32,7 +32,9 @@ final case class Options(
   @HelpMessage("Name of a class loader set up with the -i option of coursier bootstrap or coursier launch, to be used from the session")
     specialLoader: String = "user",
   @HelpMessage("Start a metabrowse server for go to source navigation (linked from Jupyter inspections)")
-    metabrowse: Boolean = false
+    metabrowse: Boolean = false,
+  @HelpMessage("Trap what user code sends to stdout and stderr")
+    trapOutput: Boolean = false
 ) {
 
   def autoDependencyMap(): Map[String, Seq[String]] =

--- a/modules/scala/scala-kernel/src/main/scala/almond/ScalaKernel.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/ScalaKernel.scala
@@ -140,7 +140,8 @@ object ScalaKernel extends CaseApp[Options] {
       initialClassLoader = initialClassLoader,
       logCtx = logCtx,
       metabrowse = options.metabrowse,
-      lazyInit = true
+      lazyInit = true,
+      trapOutput = options.trapOutput
     )
     log.info("Created interpreter")
 

--- a/modules/shared/kernel/src/test/scala/almond/kernel/KernelTests.scala
+++ b/modules/shared/kernel/src/test/scala/almond/kernel/KernelTests.scala
@@ -139,7 +139,11 @@ object KernelTests extends TestSuite {
         "execute_reply"
       )
 
-      assert(msgTypes == expectedMsgTypes)
+      val (commMsgTypes, stdMsgTypes) = msgTypes.partition(_.startsWith("comm_"))
+      val (expectedCommMsgTypes, expectedStdMsgTypes) = expectedMsgTypes.partition(_.startsWith("comm_"))
+
+      assert(commMsgTypes == expectedCommMsgTypes)
+      assert(stdMsgTypes == expectedStdMsgTypes)
     }
 
     "history request" - {


### PR DESCRIPTION
I'd like to automatically run and validate some existings notebooks… This should make their output more reproducible (trapping logs in particular, e.g. like in [this notebook](https://github.com/sbrunk/almond-examples/blob/e3bc675b60dfde2b24d1345713752d94ecc92e58/tensorflow_scala.ipynb)).