### PR TITLE
Handle connection key being empty to support Google Colaboratory

### DIFF
--- a/modules/shared/channels/src/test/scala/almond/channels/zeromq/ZeromqSocketTests.scala
+++ b/modules/shared/channels/src/test/scala/almond/channels/zeromq/ZeromqSocketTests.scala
@@ -83,6 +83,69 @@ object ZeromqSocketTests extends TestSuite {
       t.unsafeRunSync()
     }
 
+    'simpleWithNoKey - {
+
+      val repEc = ExecutionContext.fromExecutorService(
+        Executors.newSingleThreadExecutor()
+      )
+      val reqEc = ExecutionContext.fromExecutorService(
+        Executors.newSingleThreadExecutor()
+      )
+      val port = ConnectionParameters.randomPort()
+
+      val key = Secret("") // having no key disables signature checking
+
+      val logCtx = LoggerContext.nop
+
+      val rep = ZeromqSocket(
+        repEc,
+        ZMQ.REP,
+        bind = true,
+        s"tcp://localhost:$port",
+        None,
+        None,
+        ctx,
+        key,
+        "hmac-sha256",
+        logCtx
+      )
+
+      val req = ZeromqSocket(
+        reqEc,
+        ZMQ.REQ,
+        bind = false,
+        s"tcp://localhost:$port",
+        None,
+        None,
+        ctx,
+        key,
+        "hmac-sha256",
+        logCtx
+      )
+
+      val msg = Message(
+        Nil,
+        "header",
+        "parent_header",
+        "metadata",
+        "content"
+      )
+
+      val t =
+        for {
+          _ <- rep.open
+          _ <- req.open
+          _ <- req.send(msg)
+          readOpt <- rep.read
+          _ = assert(readOpt.contains(msg))
+          // FIXME Closing should be enforced via bracketing
+          _ <- req.close
+          _ <- rep.close
+        } yield ()
+
+      t.unsafeRunSync()
+    }
+
   }
 
 }


### PR DESCRIPTION
When running kernels on Google Colaboratory, the `key` value in `connection.json` is empty to indicate that authentication and signature checking should be disabled (noted in the [official docs](https://jupyter-client.readthedocs.io/en/stable/messaging.html#wire-protocol)). This PR updates `ZeromqSocketImpl` to handle the situation where `key` is empty by using an empty string as the signature when sending a message and skipping the signature check when receiving a message. With these changes, Almond works perfectly inside Colaboratory.