### PR TITLE
Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ stages:
   - name: release
     if: (branch = master AND type = push) OR (tag IS present)
   - name: upload-launcher
-    if: (branch = master AND type = push) OR tag IS present
+    if: tag IS present
   - name: update-docker-images # after upload-launcher, that waited for the sync to Maven Central
     if: tag IS present
   - name: update-versioned-docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ stages:
   - name: test
   - name: release
     if: (branch = master AND type = push) OR (tag IS present)
-  - name: upload-artifacts
+  - name: upload-launcher
+    if: (branch = master AND type = push) OR tag IS present
+  - name: update-docker-images # after upload-launcher, that waited for the sync to Maven Central
     if: tag IS present
   - name: update-versioned-docs
     if: tag IS present
@@ -48,10 +50,10 @@ jobs:
     script: amm scripts/site.sc --publishLocal true
   - stage: release
     script: sbt ci-release
-  - stage: upload-artifacts
+  - stage: upload-launcher
     name: "Upload launcher"
     script: scripts/upload-launcher.sh
-  - stage: upload-artifacts
+  - stage: update-docker-images
     name: "Update docker images"
     script: scripts/update-docker-images.sh
   - stage: update-versioned-docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ git:
 before_install:
   - source scripts/website/setup-build-tools.sh
 sudo: required
+services:
+  - docker
 stages:
   - name: test
   - name: release
     if: (branch = master AND type = push) OR (tag IS present)
-  - name: upload-launcher
-    if: tag IS present
-  - name: update-docker-images # after upload-launcher, that waited for the sync to Maven Central
+  - name: upload-artifacts
     if: tag IS present
   - name: update-versioned-docs
     if: tag IS present
@@ -48,10 +48,10 @@ jobs:
     script: amm scripts/site.sc --publishLocal true
   - stage: release
     script: sbt ci-release
-  - stage: upload-launcher
+  - stage: upload-artifacts
     name: "Upload launcher"
     script: scripts/upload-launcher.sh
-  - stage: update-docker-images
+  - stage: upload-artifacts
     name: "Update docker images"
     script: scripts/update-docker-images.sh
   - stage: update-versioned-docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ARG LOCAL_IVY=no
 
 FROM almondsh/almond:coursier as local_ivy_yes
 USER $NB_UID
-RUN mkdir -p $HOME/.ivy2/local/
-ONBUILD COPY --chown=1000:100 ivy-local/ $HOME/.ivy2/local/
+ONBUILD RUN mkdir -p .ivy2/local/
+ONBUILD COPY --chown=1000:100 ivy-local/ .ivy2/local/
 
 FROM almondsh/almond:coursier as local_ivy_no
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Dockerfile with support for creating images with kernels for multiple Scala versions.
+# Expects ALMOND_VERSION and SCALA_VERSIONS to be set as build arg, like this:
+# docker build --build-arg ALMOND_VERSION=0.3.1 --build-arg SCALA_VERSIONS="2.11.12 2.12.8" .
+
+# Set LOCAL_IVY=yes to have the contents of ivy-local copied into the image.
+# Can be used to create an image with a locally built almond that isn't on maven central yet.
+ARG LOCAL_IVY=no
+
+FROM almondsh/almond:coursier as local_ivy_yes
+USER $NB_UID
+RUN mkdir -p $HOME/.ivy2/local/
+ONBUILD COPY --chown=1000:100 ivy-local/ $HOME/.ivy2/local/
+
+FROM almondsh/almond:coursier as local_ivy_no
+
+FROM local_ivy_${LOCAL_IVY}
+ARG ALMOND_VERSION
+# Set to a single Scala version string or list of Scala versions separated by a space.
+# i.e SCALA_VERSIONS="2.11.12 2.12.8"
+ARG SCALA_VERSIONS
+USER $NB_UID
+RUN [ -z "$SCALA_VERSIONS" ] && echo "SCALA_VERSIONS is empty" && exit 1; \
+    [ -z "$ALMOND_VERSION" ] && echo "ALMOND_VERSION is empty" && exit 1; \
+    for SCALA_FULL_VERSION in ${SCALA_VERSIONS}; do \
+        # remove patch version
+        SCALA_MAJOR_VERSION=${SCALA_FULL_VERSION%.*}; \
+        # remove all dots for the kernel id
+        SCALA_MAJOR_VERSION_TRIMMED=$(echo ${SCALA_MAJOR_VERSION} | tr -d .); \
+        echo Installing almond ${ALMOND_VERSION} for Scala ${SCALA_FULL_VERSION}; \
+        coursier bootstrap \
+            -r jitpack \
+            -i user -I user:sh.almond:scala-kernel-api_${SCALA_FULL_VERSION}:${ALMOND_VERSION} \
+            sh.almond:scala-kernel_${SCALA_FULL_VERSION}:${ALMOND_VERSION} \
+            --default=true --sources \
+            -o almond && \
+        ./almond --install --log info --metabrowse --id scala${SCALA_MAJOR_VERSION_TRIMMED} --display-name "Scala ${SCALA_MAJOR_VERSION}" && \
+        rm -f almond; \
+    done; \
+    rm -rf .ivy2

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,21 +19,7 @@ ARG ALMOND_VERSION
 # i.e SCALA_VERSIONS="2.11.12 2.12.8"
 ARG SCALA_VERSIONS
 USER $NB_UID
-RUN [ -z "$SCALA_VERSIONS" ] && echo "SCALA_VERSIONS is empty" && exit 1; \
-    [ -z "$ALMOND_VERSION" ] && echo "ALMOND_VERSION is empty" && exit 1; \
-    for SCALA_FULL_VERSION in ${SCALA_VERSIONS}; do \
-        # remove patch version
-        SCALA_MAJOR_VERSION=${SCALA_FULL_VERSION%.*}; \
-        # remove all dots for the kernel id
-        SCALA_MAJOR_VERSION_TRIMMED=$(echo ${SCALA_MAJOR_VERSION} | tr -d .); \
-        echo Installing almond ${ALMOND_VERSION} for Scala ${SCALA_FULL_VERSION}; \
-        coursier bootstrap \
-            -r jitpack \
-            -i user -I user:sh.almond:scala-kernel-api_${SCALA_FULL_VERSION}:${ALMOND_VERSION} \
-            sh.almond:scala-kernel_${SCALA_FULL_VERSION}:${ALMOND_VERSION} \
-            --default=true --sources \
-            -o almond && \
-        ./almond --install --log info --metabrowse --id scala${SCALA_MAJOR_VERSION_TRIMMED} --display-name "Scala ${SCALA_MAJOR_VERSION}" && \
-        rm -f almond; \
-    done; \
+COPY scripts/install-kernels.sh .
+RUN ./install-kernels.sh && \
+    rm install-kernels.sh && \
     rm -rf .ivy2

--- a/scripts/install-kernels.sh
+++ b/scripts/install-kernels.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -eu
+
+[ -z "$SCALA_VERSIONS" ] && { echo "SCALA_VERSIONS is empty" ; exit 1; }
+[ -z "$ALMOND_VERSION" ] && { echo "ALMOND_VERSION is empty" ; exit 1; }
+for SCALA_FULL_VERSION in ${SCALA_VERSIONS}; do
+  # remove patch version
+  SCALA_MAJOR_VERSION=${SCALA_FULL_VERSION%.*}
+  # remove all dots for the kernel id
+  SCALA_MAJOR_VERSION_TRIMMED=$(echo ${SCALA_MAJOR_VERSION} | tr -d .)
+  echo Installing almond ${ALMOND_VERSION} for Scala ${SCALA_FULL_VERSION}
+  coursier bootstrap \
+      -r jitpack \
+      -i user -I user:sh.almond:scala-kernel-api_${SCALA_FULL_VERSION}:${ALMOND_VERSION} \
+      sh.almond:scala-kernel_${SCALA_FULL_VERSION}:${ALMOND_VERSION} \
+      --default=true --sources \
+      -o almond
+  ./almond --install --log info --metabrowse --id scala${SCALA_MAJOR_VERSION_TRIMMED} --display-name "Scala ${SCALA_MAJOR_VERSION}"
+  rm -f almond
+done
+echo Installation was successful

--- a/scripts/update-docker-images.sh
+++ b/scripts/update-docker-images.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-set -euv
-
-if [[ ${TRAVIS_TAG} != v* ]]; then
-  echo "Not on a git tag"
-  exit 1
-fi
+set -e
 
 SCALA212_VERSION="$(grep -oP '(?<=def scala212 = ")[^"]*(?<!")' project/Settings.scala)"
 SCALA211_VERSION="$(grep -oP '(?<=def scala211 = ")[^"]*(?<!")' project/Settings.scala)"
@@ -12,23 +7,33 @@ SCALA211_VERSION="$(grep -oP '(?<=def scala211 = ")[^"]*(?<!")' project/Settings
 ALMOND_VERSION="$(git describe --tags --abbrev=0 --match 'v*' | sed 's/^v//')"
 
 DOCKER_REPO=almondsh/almond
-IMAGE_NAME=${DOCKER_REPO}:${ALMOND_VERSION}
-
-sbt '+ publishLocal'
-cp -r $HOME/.ivy2/local/ ivy-local/
-
-docker build --build-arg ALMOND_VERSION=${ALMOND_VERSION} --build-arg=LOCAL_IVY=yes \
-  --build-arg SCALA_VERSIONS="$SCALA211_VERSION $SCALA212_VERSION" -t ${IMAGE_NAME} .
-docker build --build-arg ALMOND_VERSION=${ALMOND_VERSION} --build-arg=LOCAL_IVY=yes \
-  --build-arg SCALA_VERSIONS="$SCALA211_VERSION" -t ${IMAGE_NAME}-scala-${SCALA211_VERSION} .
-docker build --build-arg ALMOND_VERSION=${ALMOND_VERSION} --build-arg=LOCAL_IVY=yes \
-  --build-arg SCALA_VERSIONS="$SCALA212_VERSION" -t ${IMAGE_NAME}-scala-${SCALA212_VERSION} .
 
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-docker push ${IMAGE_NAME}-scala-${SCALA211_VERSION}
-docker push ${IMAGE_NAME}-scala-${SCALA212_VERSION}
-docker push ${IMAGE_NAME}
+if [[ ${TRAVIS_TAG} != v* ]]; then
+  echo "Not on a git tag, creating snapshot image"
+  ALMOND_VERSION=${ALMOND_VERSION%.*}.$((${ALMOND_VERSION##*.} + 1))-SNAPSHOT
+  IMAGE_NAME=${DOCKER_REPO}:snapshot
+  sbt '+ publishLocal'
+  cp -r $HOME/.ivy2/local/ ivy-local/
+  docker build --build-arg ALMOND_VERSION=${ALMOND_VERSION} --build-arg=LOCAL_IVY=yes \
+    --build-arg SCALA_VERSIONS="$SCALA211_VERSION $SCALA212_VERSION" -t ${IMAGE_NAME} .
+  docker push ${IMAGE_NAME}
+else
+  echo "Creating release images for almond ${ALMOND_VERSION}"
+  IMAGE_NAME=${DOCKER_REPO}:${ALMOND_VERSION}
+  docker build --build-arg ALMOND_VERSION=${ALMOND_VERSION} \
+    --build-arg SCALA_VERSIONS="$SCALA211_VERSION $SCALA212_VERSION" -t ${IMAGE_NAME} .
+  docker build --build-arg ALMOND_VERSION=${ALMOND_VERSION} \
+    --build-arg SCALA_VERSIONS="$SCALA211_VERSION" -t ${IMAGE_NAME}-scala-${SCALA211_VERSION} .
+  docker build --build-arg ALMOND_VERSION=${ALMOND_VERSION} \
+    --build-arg SCALA_VERSIONS="$SCALA212_VERSION" -t ${IMAGE_NAME}-scala-${SCALA212_VERSION} .
 
-docker tag ${IMAGE_NAME} ${DOCKER_REPO}:latest
-docker push ${DOCKER_REPO}:latest
+  docker push ${IMAGE_NAME}-scala-${SCALA211_VERSION}
+  docker push ${IMAGE_NAME}-scala-${SCALA212_VERSION}
+  docker push ${IMAGE_NAME}
+  docker tag ${IMAGE_NAME} ${DOCKER_REPO}:latest
+  docker push ${DOCKER_REPO}:latest
+fi
+
+


### PR DESCRIPTION
This is an alternative approach to https://github.com/almond-sh/docker-images/pull/1.

The main differences are:
* We have a single generic Dockerfile in the main repo.
* When a tag is pushed, we use travis to build docker images with kernels for 2.11, 2.12 and both, and push them to docker hub.

The Dockerfile makes it easy to create a docker image from a locally built kernel by setting `LOCAL_IVY=yes`. This is used in travis where the images are created from locally published jars, which is why we can run this job in parallel to uploading to sonatype.

Right now it does a `sbt + publishLocal` in the update-docker-images script, then copies `$HOME/.ivy/local` into `$TRAVIS_BUILD_DIR/ivy-local` so we can copy it into the docker image. I think this could be improved by doing an additional publish to `$TRAVIS_BUILD_DIR/ivy-local` during the release stage directly. I tried but my understanding of sbt seems to be too limited.