### PR TITLE
Comm Enhancements

### DIFF
--- a/modules/scala/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/SendLog.scala
+++ b/modules/scala/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/SendLog.scala
@@ -81,12 +81,13 @@ final class SendLog(
         try {
           withExponentialBackOff {
             commHandler.commOpen(
-              commTarget,
-              commId,
-              Json.obj(
+              targetName = commTarget,
+              id = commId,
+              data = Json.obj(
                 "file_name" -> Json.jString(fileName0),
                 "prefix" -> prefix.fold(Json.jNull)(Json.jString)
-              ).nospaces
+              ).nospaces,
+              metadata = "{}"
             )
           }
 
@@ -122,7 +123,7 @@ final class SendLog(
               lines.clear()
 
               withExponentialBackOff {
-                commHandler.commMessage(commId, res)
+                commHandler.commMessage(commId, res, "{}")
               }
             }
           }
@@ -133,7 +134,7 @@ final class SendLog(
           if (r != null)
             r.close()
           // no re-attempt here…
-          commHandler.commClose(commId, "{}")
+          commHandler.commClose(commId, "{}", "{}")
         }
       }
     }

--- a/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/CommHandler.scala
+++ b/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/CommHandler.scala
@@ -26,9 +26,12 @@ abstract class CommHandler extends OutputHandler.UpdateHelpers {
   def registerCommTarget(name: String, target: CommTarget): Unit
   def unregisterCommTarget(name: String): Unit
 
-  def commOpen(targetName: String, id: String, data: String): Unit
-  def commMessage(id: String, data: String): Unit
-  def commClose(id: String, data: String): Unit
+  @throws(classOf[IllegalArgumentException])
+  def commOpen(targetName: String, id: String, data: String, metadata: String): Unit
+  @throws(classOf[IllegalArgumentException])
+  def commMessage(id: String, data: String, metadata: String): Unit
+  @throws(classOf[IllegalArgumentException])
+  def commClose(id: String, data: String, metadata: String): Unit
 
 
   final def receiver(
@@ -50,14 +53,15 @@ abstract class CommHandler extends OutputHandler.UpdateHelpers {
   final def sender(
     targetName: String,
     id: String = UUID.randomUUID().toString,
-    data: String = "{}"
+    data: String = "{}",
+    metadata: String = "{}"
   ): Comm = {
-    commOpen(targetName, id, data)
+    commOpen(targetName, id, data, metadata)
     new Comm {
-      def message(data: String) =
-        commMessage(id, data)
-      def close(data: String) =
-        commClose(id, data)
+      def message(data: String, metadata: String = "{}") =
+        commMessage(id, data, metadata)
+      def close(data: String, metadata: String = "{}") =
+        commClose(id, data, metadata)
     }
   }
 }
@@ -65,8 +69,8 @@ abstract class CommHandler extends OutputHandler.UpdateHelpers {
 object CommHandler {
 
   abstract class Comm {
-    def message(data: String): Unit
-    def close(data: String): Unit
+    def message(data: String, metadata: String): Unit
+    def close(data: String, metadata: String): Unit
   }
 
 }

--- a/modules/shared/interpreter/src/main/scala/almond/interpreter/comm/DefaultCommHandler.scala
+++ b/modules/shared/interpreter/src/main/scala/almond/interpreter/comm/DefaultCommHandler.scala
@@ -5,12 +5,13 @@ import almond.interpreter.api.{CommHandler, CommTarget, DisplayData}
 import almond.interpreter.util.DisplayDataOps._
 import almond.interpreter.Message
 import almond.protocol._
-import argonaut.{EncodeJson, JsonObject}
+import argonaut.{EncodeJson, Json, JsonObject}
 import argonaut.Parse.{parse => parseJson}
 import cats.effect.IO
 import fs2.concurrent.Queue
 
 import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 final class DefaultCommHandler(
   queue: Queue[IO, (Channel, RawMessage)],
@@ -21,8 +22,8 @@ final class DefaultCommHandler(
 
   private val message: Message[_] =
     Message(
-      Header("", "username", "", "", Some(Protocol.versionStr)), // FIXME Hardcoded user / session id
-      ()
+      header = Header("", "username", "", "", Some(Protocol.versionStr)), // FIXME Hardcoded user / session id
+      content = ()
     )
 
 
@@ -35,31 +36,26 @@ final class DefaultCommHandler(
     commTargetManager.addTarget(name, target)
 
 
-  private def publish[T: EncodeJson](messageType: MessageType[T], content: T): Unit =
+  private def publish[T: EncodeJson](messageType: MessageType[T], content: T, metadata: Map[String, Json]): Unit =
     message
-      .publish(messageType, content)
+      .publish(messageType, content, metadata)
       .enqueueOn(Channel.Publish, queue)
       .unsafeRunSync()
 
-  private def parseJsonObj(s: String): Option[JsonObject] =
+  private def parseJsonObj(s: String): Try[JsonObject] =
     parseJson(s)
-      .right
-      .toOption
-      .flatMap(_.obj)
+      .right.flatMap(_.obj.toRight("Not a JSON object"))
+      .left.map(new IllegalArgumentException(_))
+      .toTry
 
-  // TODO Throw an exception if bad data is passed
+  def commOpen(targetName: String, id: String, data: String, metadata: String): Unit =
+    publish(Comm.openType, Comm.Open(id, targetName, parseJsonObj(data).get), parseJsonObj(metadata).get.toMap)
 
-  def commOpen(targetName: String, id: String, data: String): Unit =
-    for (obj <- parseJsonObj(data))
-      publish(Comm.openType, Comm.Open(id, targetName, obj))
+  def commMessage(id: String, data: String, metadata: String): Unit =
+    publish(Comm.messageType, Comm.Message(id, parseJsonObj(data).get), parseJsonObj(metadata).get.toMap)
 
-  def commMessage(id: String, data: String): Unit =
-    for (obj <- parseJsonObj(data))
-      publish(Comm.messageType, Comm.Message(id, obj))
-
-  def commClose(id: String, data: String): Unit =
-    for (obj <- parseJsonObj(data))
-      publish(Comm.closeType, Comm.Close(id, obj))
+  def commClose(id: String, data: String, metadata: String): Unit =
+    publish(Comm.closeType, Comm.Close(id, parseJsonObj(data).get), parseJsonObj(metadata).get.toMap)
 
 
   def updateDisplay(data: DisplayData): Unit = {
@@ -72,6 +68,6 @@ final class DefaultCommHandler(
       Execute.DisplayData.Transient(data.idOpt)
     )
 
-    publish(Execute.updateDisplayDataType, content)
+    publish(Execute.updateDisplayDataType, content, Map.empty)
   }
 }

--- a/modules/shared/interpreter/src/main/scala/almond/interpreter/comm/DefaultCommHandler.scala
+++ b/modules/shared/interpreter/src/main/scala/almond/interpreter/comm/DefaultCommHandler.scala
@@ -42,20 +42,19 @@ final class DefaultCommHandler(
       .enqueueOn(Channel.Publish, queue)
       .unsafeRunSync()
 
-  private def parseJsonObj(s: String): Try[JsonObject] =
+  private def parseJsonObj(s: String): JsonObject =
     parseJson(s)
       .right.flatMap(_.obj.toRight("Not a JSON object"))
-      .left.map(new IllegalArgumentException(_))
-      .toTry
+      .fold(left => throw new IllegalArgumentException(left), identity)
 
   def commOpen(targetName: String, id: String, data: String, metadata: String): Unit =
-    publish(Comm.openType, Comm.Open(id, targetName, parseJsonObj(data).get), parseJsonObj(metadata).get.toMap)
+    publish(Comm.openType, Comm.Open(id, targetName, parseJsonObj(data)), parseJsonObj(metadata).toMap)
 
   def commMessage(id: String, data: String, metadata: String): Unit =
-    publish(Comm.messageType, Comm.Message(id, parseJsonObj(data).get), parseJsonObj(metadata).get.toMap)
+    publish(Comm.messageType, Comm.Message(id, parseJsonObj(data)), parseJsonObj(metadata).toMap)
 
   def commClose(id: String, data: String, metadata: String): Unit =
-    publish(Comm.closeType, Comm.Close(id, parseJsonObj(data).get), parseJsonObj(metadata).get.toMap)
+    publish(Comm.closeType, Comm.Close(id, parseJsonObj(data)), parseJsonObj(metadata).toMap)
 
 
   def updateDisplay(data: DisplayData): Unit = {

--- a/modules/shared/interpreter/src/main/scala/almond/interpreter/comm/DefaultCommHandler.scala
+++ b/modules/shared/interpreter/src/main/scala/almond/interpreter/comm/DefaultCommHandler.scala
@@ -11,7 +11,6 @@ import cats.effect.IO
 import fs2.concurrent.Queue
 
 import scala.concurrent.ExecutionContext
-import scala.util.Try
 
 final class DefaultCommHandler(
   queue: Queue[IO, (Channel, RawMessage)],
@@ -34,6 +33,11 @@ final class DefaultCommHandler(
 
   def registerCommTarget(name: String, target: IOCommTarget): Unit =
     commTargetManager.addTarget(name, target)
+
+  def registerCommId(id: String, target: CommTarget): Unit =
+    commTargetManager.addId(IOCommTarget.fromCommTarget(target, commEc), id)
+  def unregisterCommId(id: String): Unit =
+    commTargetManager.removeId(id)
 
 
   private def publish[T: EncodeJson](messageType: MessageType[T], content: T, metadata: Map[String, Json]): Unit =

--- a/modules/shared/interpreter/src/test/scala/almond/interpreter/TestInterpreter.scala
+++ b/modules/shared/interpreter/src/test/scala/almond/interpreter/TestInterpreter.scala
@@ -34,7 +34,7 @@ final class TestInterpreter extends Interpreter {
           ExecuteResult.Error("comm not available")
         case Some(h) =>
           val target = code.stripPrefix("comm-open:")
-          h.commOpen(target, target, "{}")
+          h.commOpen(target, target, "{}", "{}")
           count += 1
           ExecuteResult.Success()
       }
@@ -44,7 +44,7 @@ final class TestInterpreter extends Interpreter {
           ExecuteResult.Error("comm not available")
         case Some(h) =>
           val target = code.stripPrefix("comm-message:")
-          h.commMessage(target, """{"a": "b"}""")
+          h.commMessage(target, """{"a": "b"}""", "{}")
           count += 1
           ExecuteResult.Success()
       }
@@ -54,7 +54,7 @@ final class TestInterpreter extends Interpreter {
           ExecuteResult.Error("comm not available")
         case Some(h) =>
           val target = code.stripPrefix("comm-close:")
-          h.commClose(target, "{}")
+          h.commClose(target, "{}", "{}")
           count += 1
           ExecuteResult.Success()
       }

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -10,13 +10,13 @@ object Mima {
       .forall(c => c == '.' || c == '-' || c.isDigit)
 
   def binaryCompatibilityVersions(): Set[String] =
-    Seq("git", "tag", "--merged", "HEAD^", "--contains", "v0.6.0")
+    Seq("git", "tag", "--merged", "HEAD^", "--contains", "v0.7.0")
       .!!
       .linesIterator
       .map(_.trim)
       .filter(_.startsWith("v"))
       .map(_.stripPrefix("v"))
-      .filter(_ != "0.6.0") // Preserving compatibility right after it
+      .filter(_ != "0.7.0") // Preserving compatibility right after it
       .filter(stable)
       .toSet
 

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -9,14 +9,14 @@ object Mima {
       .replace("-RC", "-")
       .forall(c => c == '.' || c == '-' || c.isDigit)
 
-  def binaryCompatibilityVersions(contains: String): Set[String] =
-    Seq("git", "tag", "--merged", "HEAD^", "--contains", contains)
+  def binaryCompatibilityVersions(): Set[String] =
+    Seq("git", "tag", "--merged", "HEAD^", "--contains", "v0.6.0")
       .!!
       .linesIterator
       .map(_.trim)
       .filter(_.startsWith("v"))
       .map(_.stripPrefix("v"))
-      .filter(_ != "0.6.0") // Mima enabled right after it
+      .filter(_ != "0.6.0") // Preserving compatibility right after it
       .filter(stable)
       .toSet
 

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -16,7 +16,7 @@ object Mima {
       .map(_.trim)
       .filter(_.startsWith("v"))
       .map(_.stripPrefix("v"))
-      .filter(_ != "0.3.1") // Mima enabled right after it
+      .filter(_ != "0.6.0") // Mima enabled right after it
       .filter(stable)
       .toSet
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -213,11 +213,8 @@ object Settings {
   lazy val mima = Seq(
     MimaPlugin.autoImport.mimaPreviousArtifacts := {
       val sv = scalaVersion.value
-      val contains =
-        if (sv.startsWith("2.13.")) "4e9441b9"
-        else "v0.3.1"
 
-      Mima.binaryCompatibilityVersions(contains).map { ver =>
+      Mima.binaryCompatibilityVersions().map { ver =>
         (organization.value % moduleName.value % ver).cross(crossVersion.value)
       }
     }


### PR DESCRIPTION
ipywidgets sets its protocol version in the metadata of the comm messages it sends.

This is an attempt to support setting metadata for comm messages. Sending comm messages also throws exceptions now if data or metadata can't be parsed into JSON objects (it was a TODO before in `DefaultCommHandler`).