### PR TITLE
Add ok status to KernelInfo replies. Fixes #398

### DIFF
--- a/modules/shared/protocol/src/main/scala/almond/protocol/KernelInfo.scala
+++ b/modules/shared/protocol/src/main/scala/almond/protocol/KernelInfo.scala
@@ -4,6 +4,7 @@ import argonaut.ArgonautShapeless._
 import argonaut.EncodeJson
 
 final case class KernelInfo(
+  status: String, // "ok"
   protocol_version: String, // X.Y.Z
   implementation: String,
   implementation_version: String, // X.Y.Z
@@ -22,6 +23,7 @@ object KernelInfo {
     help_links: Option[List[KernelInfo.Link]]
   ): KernelInfo =
     KernelInfo(
+      status = "ok",
       Protocol.versionStr,
       implementation,
       implementation_version,
@@ -37,6 +39,7 @@ object KernelInfo {
     banner: String
   ): KernelInfo =
     KernelInfo(
+      status = "ok",
       Protocol.versionStr,
       implementation,
       implementation_version,


### PR DESCRIPTION
This should solve the syntax highlighting issues described in #398.