### PR TITLE
Use a more recent Docker daemon in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,10 @@ jobs:
     script: scripts/upload-launcher.sh
   - stage: update-docker-images
     name: "Update docker images"
+    addons:
+      apt:
+        packages:
+          - docker-ce
     script: scripts/update-docker-images.sh
   - stage: update-versioned-docs
     env: WEBSITE_DIR=docs/website VERSIONED_DOCS_REPO=almond-sh/versioned-docs


### PR DESCRIPTION
This should help with #444 as travis uses an older non BuildKit based Docker daemon by default that can't skip executing unused build stages.