### PR TITLE
Use custom sbt launcher via workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "metals.sbtScript": "./sbt"
+}


### PR DESCRIPTION
Should make importing almond in vscode  work out-of-the-box.