### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/docs/website/siteConfig.js
+++ b/docs/website/siteConfig.js
@@ -2,6 +2,11 @@
 // site configuration options.
 
 const siteConfig = {
+  algolia: {
+    apiKey: '2cf058a89a451066357a2eece168e7af',
+    indexName: 'almond',
+  },
+  
   title: 'almond',
   tagline: 'A Scala kernel for Jupyter',
 


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.