### PR TITLE
Don't require sbt-coursier anymore

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "metals.sbtScript": "./sbt"
-}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.7.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.12")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "2.0.0-RC4-1")


### PR DESCRIPTION
This also allows to use vanilla sbt launchers.