### PR TITLE
Use almond from coursier apps in the installation instructions

### DIFF
--- a/docs/pages/dev-from-sources.md
+++ b/docs/pages/dev-from-sources.md
@@ -86,9 +86,8 @@ Create a launcher with
 ```bash
 $ SCALA_VERSION=2.12.7 ALMOND_VERSION=0.1.11-SNAPSHOT
 $ coursier bootstrap \
-    -r jitpack \
-    -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \
-    sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
+    almond:$ALMOND_VERSION \
+    --scala $SCALA_VERSION \
     --sources --default=true \
     -o almond-snapshot --embed-files=false
 ```

--- a/docs/pages/install-multiple.md
+++ b/docs/pages/install-multiple.md
@@ -10,33 +10,18 @@ have different ids (required) and display names (recommended).
 
 For example, let's install almond for the scala `2.13.0` version,
 ```bash
-$ SCALA_VERSION=2.13.0 ALMOND_VERSION=@VERSION@
-$ coursier bootstrap @EXTRA_COURSIER_ARGS@\
-    -r jitpack \
-    -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \
-    sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
-    --sources --default=true \
-    -o almond
-$ ./almond --install
-$ rm -f almond
+$ cs launch almond --scala 2.13.0 -- --install
 ```
 
 This installs almond with the default kernel id, `scala`, and default display name, "Scala".
 
 Now let's *also* install almond for scala `2.12.9`,
 ```bash
-$ SCALA_VERSION=2.12.9 ALMOND_VERSION=@VERSION@
-$ coursier bootstrap @EXTRA_COURSIER_ARGS@\
-    -r jitpack \
-    -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \
-    sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
-    --sources --default=true \
-    -o almond-scala-2.12
-$ ./almond-scala-2.12 --install --id scala212 --display-name "Scala (2.12)"
-$ rm -f almond-scala-2.12
+$ cs launch almond:@VERSION@ --scala 2.12.9 \
+      -- --install --id scala212 --display-name "Scala (2.12)"
 ```
 
-`--id scala211` ensures this kernel is installed along side the former, in a directory
+`--id scala212` ensures this kernel is installed along side the former, in a directory
 with a different name.
 
 `--display-name "Scala (2.12)"` ensures users can differentiate both kernels, with the latter

--- a/docs/pages/install-other.md
+++ b/docs/pages/install-other.md
@@ -4,18 +4,19 @@ title: Other
 
 ## All-included launcher
 
-The launcher above downloads the JARs it needs upon launch. These JARs are downloaded to /
-picked from the cache of coursier. You may prefer to have the launcher embed all these JARs,
+When launched by other users, the kernel installed by the default command
+downloads its dependencies in the user-specific [coursier cache](https://get-coursier.io/docs/cache.html#location)
+upon first launch.
+
+You may prefer to have the launcher embed all these JARs,
 so that nothing needs to be downloaded or picked from a cache upon launch. Passing
 `--standalone` to the `coursier bootstrap` command generates such a launcher,
 ```bash
-$ SCALA_VERSION=@SCALA_VERSION@ ALMOND_VERSION=@VERSION@
 $ coursier bootstrap --standalone \
-    -r jitpack \
-    -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \
-    sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
-    --sources --default=true \
+    almond:@VERSION@ --scala @SCALA_VERSION@ \
     -o almond
+$ ./almond --install
+$ rm -f almond # the generated launcher can be removed after install, it copied itself in the kernel installation directory
 ```
 but that launcher won't work fine until something like https://github.com/lihaoyi/Ammonite/pull/850
 is merged in Ammonite.

--- a/docs/pages/quick-start-install.md
+++ b/docs/pages/quick-start-install.md
@@ -2,83 +2,62 @@
 title: Installation
 ---
 
-## Create a launcher
+## Install the almond kernel
 
-1. Set the desired version of Scala and Almond as environment variables:
-
-```bash
-$ SCALA_VERSION=@SCALA_VERSION@ ALMOND_VERSION=@VERSION@
+A Java Virtual Machine (JVM) needs to be installed on your system. You
+can check if a JVM is installed by running
+```text
+$ java -version
+java version "1.8.0_121"
+Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
+Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)
 ```
+If you don't have a JVM yet, we recommend installing [AdoptOpenJDK](https://adoptopenjdk.net) version 8.
 
-<details>
-<summary>Equivalent Windows command</summary>
-```bat
-> set SCALA_VERSION=@SCALA_VERSION@
-> set ALMOND_VERSION=@VERSION@
-```
-</details>
-
-The available versions of Scala and Almond are can be found [here](https://github.com/almond-sh/almond/releases).
-Adjust `ALMOND_VERSION` and `SCALA_VERSION` at your convenience to meet your
-needs. Not all combinations are guaranteed to be available. See the available
-combinations [here](install-versions.md)).
-
-2. Create a launcher via [coursier](http://get-coursier.io):
-
-```bash
+Almond can then be fetched and installed with [coursier](http://get-coursier.io),
+like
+```text
 $ curl -Lo coursier https://git.io/coursier-cli
 $ chmod +x coursier
-$ ./coursier bootstrap @EXTRA_COURSIER_ARGS@\
-    -r jitpack \
-    -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \
-    sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
-    -o almond
+$ ./coursier launch almond -- --install
+$ rm -f coursier
 ```
+
+Note the `--` before `--install`, separating the arguments passed to Almond
+from the ones handled by coursier.
+
+You can specify explicit Almond and / or Scala versions, like
+```text
+$ ./coursier launch almond:0.10.0 --scala 2.12.11 -- --install
+```
+
+Short Scala versions, like just `2.12` or `2.13`, are accepted too.
+The available versions of Almond can be found [here](https://github.com/almond-sh/almond/releases).
+Not all Almond and Scala versions combinations are available.
+See the possible combinations [here](install-versions.md)).
+
 
 <details>
 <summary>Equivalent Windows command</summary>
 ```bat
 > bitsadmin /transfer downloadCoursierCli https://git.io/coursier-cli "%cd%\coursier"
 > bitsadmin /transfer downloadCoursierBat https://git.io/coursier-bat "%cd%\coursier.bat"
-> .\coursier bootstrap ^
-    -r jitpack ^
-    -i user -I user:sh.almond:scala-kernel-api_%SCALA_VERSION%:%ALMOND_VERSION% ^
-    sh.almond:scala-kernel_%SCALA_VERSION%:%ALMOND_VERSION% ^
-    -o almond
-> .\almond --install
+> .\coursier launch almond -- --install
 ```
 </details>
 
-## Install the almond kernel
-
-3. Run the launcher to install the almond kernel:
-
-```bash
-$ ./almond --install
-```
-
-<details>
-<summary>Equivalent Windows command</summary>
-```bat
-> .\almond --install
-```
-</details>
-
-4. Once the kernel is installed, you can use it within Jupyter or nteract.
-
-If you are satisfied that the kernel is working properly, you may safely
-remove the almond launcher: `rm -f almond`
+Once the kernel is installed, you can use it within Jupyter or nteract.
 
 ## Getting help about the launcher
 
-- Help: `./almond --help`
-- Available options:
-
-Once the kernel is installed, the generated launcher can then be safely removed, with `rm -f almond`.
+Pass `--help` instead of `--install`, like
+```text
+$ ./coursier launch almond -- --help
+```
 
 ## Update the almond kernel
 
-To update the almond kernel, just re-install it, but passing the `--force` option to almond (like `./almond --install --force`). That will override any previous almond (or kernel with name `scala`).
+To update the almond kernel, just re-install it, but passing the `--force` option to almond (like `./coursier launch almond -- --install --force`). That will override any previous almond (or kernel with name `scala`).
 
 ## Uninstall the almond kernel
 


### PR DESCRIPTION
This considerably simplifies the coursier command starting almond.