### PR TITLE
scalafmt support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,12 @@ lazy val `scala-kernel-api` = project
         previous
     },
     crossVersion := CrossVersion.full,
-    generatePropertyFile("almond/almond.properties"),
+    generatePropertyFile(
+      "almond/almond.properties",
+      extraProperties = Seq(
+        "default-scalafmt-version" -> Deps.Versions.scalafmt
+      )
+    ),
     generateDependenciesFile,
     libraryDependencies ++= Seq(
       Deps.ammoniteReplApi.value,
@@ -195,11 +200,15 @@ lazy val `scala-kernel` = project
   .underScala
   .enablePlugins(PackPlugin)
   .disablePlugins(MimaPlugin)
-  .dependsOn(kernel, `scala-interpreter`)
+  .dependsOn(kernel, `scala-interpreter`, `scala-interpreter` % "test->test")
   .settings(
     shared,
     crossVersion := CrossVersion.full,
-    libraryDependencies += Deps.caseApp,
+    libraryDependencies ++= Seq(
+      Deps.caseApp,
+      Deps.scalafmtDynamic
+    ),
+    utest,
     packExcludeArtifactTypes -= "source",
     packModuleEntries ++= {
       val report = updateClassifiers.value

--- a/modules/scala/scala-kernel-api/src/main/scala/almond/api/Properties.scala
+++ b/modules/scala/scala-kernel-api/src/main/scala/almond/api/Properties.scala
@@ -25,5 +25,6 @@ object Properties {
   lazy val commitHash = Option(props.getProperty("commit-hash")).getOrElse("[unknown]")
 
   lazy val ammoniteSparkVersion = Option(props.getProperty("ammonite-spark-version")).getOrElse("[unknown]")
+  lazy val defaultScalafmtVersionOpt = Option(props.getProperty("default-scalafmt-version"))
 
 }

--- a/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
@@ -51,7 +51,9 @@ final case class Options(
   @HelpMessage("Whether to automatically update lazy val-s upon computation")
     autoUpdateLazyVals: Boolean = true,
   @HelpMessage("Whether to automatically update var-s upon change")
-    autoUpdateVars: Boolean = true
+    autoUpdateVars: Boolean = true,
+  @HelpMessage("Whether to process format requests with scalafmt")
+    scalafmt: Boolean = true
 ) {
 
   private lazy val sbv = scala.util.Properties.versionNumberString.split('.').take(2).mkString(".")

--- a/modules/scala/scala-kernel/src/main/scala/almond/Scalafmt.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/Scalafmt.scala
@@ -1,0 +1,78 @@
+package almond
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+import java.util.concurrent.ConcurrentHashMap
+
+import almond.channels.Channel
+import almond.interpreter.messagehandlers.MessageHandler
+import almond.logger.LoggerContext
+import almond.protocol.custom.Format
+import cats.effect.IO
+import cats.implicits._
+import com.typesafe.config.ConfigFactory
+import org.scalafmt.interfaces.{Scalafmt => ScalafmtInterface}
+
+import scala.concurrent.ExecutionContext
+
+final class Scalafmt(
+  fmtPool: ExecutionContext,
+  queueEc: ExecutionContext,
+  logCtx: LoggerContext,
+  defaultVersion: String = almond.api.Properties.defaultScalafmtVersionOpt.getOrElse("2.6.4")
+) {
+
+  private val log = logCtx(getClass)
+
+  private lazy val interface =
+    ScalafmtInterface.create(Thread.currentThread().getContextClassLoader)
+
+  private val confFilesMap = new ConcurrentHashMap[String, Path]
+  private def confFile(conf: String): Path = {
+    val confFile = Files.createTempFile("test-scalafmt", ".conf")
+    confFile.toFile.deleteOnExit()
+    Files.write(confFile, conf.getBytes(StandardCharsets.UTF_8))
+    val previousOrNull = confFilesMap.putIfAbsent(conf, confFile)
+    if (previousOrNull == null) confFile
+    else {
+      Files.delete(confFile)
+      previousOrNull
+    }
+  }
+
+  private val defaultDummyPath = Paths.get("/foo.sc")
+
+  private def format(code: String): String =
+    // TODO Get version via build.sbt
+    interface.format(confFile(s"version=$defaultVersion"), defaultDummyPath, code)
+      .stripSuffix("\n") // System.lineSeparator() instead?
+
+  def messageHandler: MessageHandler =
+    MessageHandler.blocking(Channel.Requests, Format.requestType, queueEc, logCtx) {
+      (msg, queue) =>
+        log.info(s"format message: $msg")
+        val sendResponses = msg.content.cells.toVector.traverse {
+          case (key, code) =>
+            for {
+              formatted <- IO.shift(fmtPool) *> IO(format(code))
+              _ <- msg
+                .publish(
+                  Format.responseType,
+                  Format.Response(key = key, initial_code = code, code = Some(formatted)),
+                  ident = Some("scalafmt")
+                )
+                .enqueueOn(Channel.Publish, queue)
+            } yield ()
+        }
+        val sendReply = {
+          val reply = Format.Reply()
+          msg
+            .reply(Format.replyType, reply)
+            .enqueueOn(Channel.Requests, queue)
+        }
+        for {
+          _ <- sendResponses
+          _ <- sendReply
+        } yield ()
+    }
+}

--- a/modules/scala/scala-kernel/src/test/scala/almond/ScalafmtTests.scala
+++ b/modules/scala/scala-kernel/src/test/scala/almond/ScalafmtTests.scala
@@ -1,0 +1,174 @@
+package almond
+
+import java.util.concurrent.Executors
+
+import almond.channels.{Channel, Message => RawMessage}
+import almond.interpreter.Message
+import almond.logger.{Level, LoggerContext}
+import almond.protocol.{Header, RawJson}
+import almond.protocol.custom.Format
+import almond.util.ThreadUtil.daemonThreadFactory
+import cats.effect.IO
+import com.github.plokhotnyuk.jsoniter_scala.core.{readFromArray, writeToArray}
+import utest._
+
+import scala.collection.immutable.ListMap
+import scala.concurrent.ExecutionContext
+import almond.protocol.Status
+
+
+object ScalafmtTests extends TestSuite {
+
+  val fmtPool = ExecutionContext.fromExecutorService(coursier.cache.internal.ThreadUtil.fixedThreadPool(1))
+
+  val queueEc = ExecutionContext.fromExecutorService(
+    Executors.newSingleThreadExecutor(daemonThreadFactory("test-queue"))
+  )
+
+  override def utestAfterAll(): Unit = {
+    fmtPool.shutdown()
+    queueEc.shutdown()
+  }
+
+  def logCtx = almond.TestLogging.logCtx
+
+  private def messages(
+    scalafmt: Scalafmt,
+    request: Format.Request
+  ): Seq[(Channel, Message[RawJson])] = {
+    val msg = Message(
+      Header.random("jovian", Format.requestType),
+      RawJson(writeToArray(request))
+    )
+    val messages = scalafmt.messageHandler.handle(Channel.Requests, msg) match {
+      case None => sys.error("format request left untouched")
+      case Some(Left(e)) => throw new Exception("Error testing format request", e)
+      case Some(Right(stream)) =>
+        stream
+          .compile
+          .toVector
+          .unsafeRunSync()
+          .map {
+            case (c, m) =>
+              val decoded = Message.parse[RawJson](m) match {
+                case Left(e) => throw new Exception(s"Error decoding $m", e)
+                case Right(m0) => m0
+              }
+              (c, decoded)
+          }
+    }
+    messages.filter {
+      case (Channel.Publish, m) if m.header.msg_type == Status.messageType.messageType => false
+      case _ => true
+    }
+  }
+
+  private def endsWithFormatReply(messages: Seq[(Channel, Message[RawJson])]): Seq[(Channel, Message[RawJson])] = {
+    assert(messages.nonEmpty)
+    // FIXME Could publish / request messages be out-of-order here?
+    val (responseChannel, response) = messages.last
+    assert(responseChannel == Channel.Requests)
+    assert(response.header.msg_type == Format.replyType.messageType)
+    messages.init
+  }
+
+  private def onlyFormatResponses(messages: Seq[(Channel, Message[RawJson])]): Map[String, Format.Response] =
+    messages
+      .map {
+        case (Channel.Publish, m) if m.header.msg_type == Format.responseType.messageType =>
+          val resp = readFromArray[Format.Response](m.content.value)
+          resp.key -> resp
+        case (c, m) =>
+          sys.error(s"Unexpected message ${m.header.msg_type} on channel $c ($m)")
+      }
+      .toMap
+
+
+  val snippet1 =
+    """def f(  n    :Int):    String
+      |          =
+      |   (                                     n+           1)                   .
+      |                 toString
+      |""".stripMargin
+  val formattedSnippet1 =
+    """def f(n: Int): String =
+      |  (n + 1).toString""".stripMargin
+
+  val snippet2 =
+    """def g (n :Int) :String=
+      |    ( n  +  2 ). toString
+      |""".stripMargin
+  val formattedSnippet2 =
+    """def g(n: Int): String =
+      |  (n + 2).toString""".stripMargin
+
+  val scalafmt = new Scalafmt(fmtPool, queueEc, logCtx)
+
+  val tests = Tests {
+
+    "empty" - {
+      val request = Format.Request(ListMap())
+      val messages0 = messages(scalafmt, request)
+      val processMessages = endsWithFormatReply(messages0)
+      assert(processMessages.isEmpty)
+    }
+
+    "simple" - {
+      val initialCode = snippet1
+      val expectedCode = formattedSnippet1
+
+      val request = Format.Request(ListMap(
+        "cell1" -> initialCode
+      ))
+      val messages0 = messages(scalafmt, request)
+      val processMessages = endsWithFormatReply(messages0)
+      assert(processMessages.length == 1)
+      val formattedCodeMap = onlyFormatResponses(processMessages)
+      println(formattedCodeMap)
+
+      val resp = formattedCodeMap.getOrElse(
+        "cell1",
+        sys.error("No data for key 'cell1' in response")
+      )
+      assert(resp.initial_code == initialCode)
+      val formattedCode = resp.code.getOrElse {
+        sys.error(s"Formatting failed (no formatted code in response for input '$snippet1')")
+      }
+      assert(formattedCode == expectedCode)
+    }
+
+    "multiple cells" - {
+      val request = Format.Request(ListMap(
+        "cell1" -> snippet1,
+        "cell2" -> snippet2
+      ))
+      val messages0 = messages(scalafmt, request)
+      val processMessages = endsWithFormatReply(messages0)
+      assert(processMessages.length == 2)
+      val formattedCodeMap = onlyFormatResponses(processMessages)
+      println(formattedCodeMap)
+
+      val resp1 = formattedCodeMap.getOrElse(
+        "cell1",
+        sys.error("No data for key 'cell1' in response")
+      )
+      assert(resp1.initial_code == snippet1)
+      val formattedCode1 = resp1.code.getOrElse {
+        sys.error(s"Formatting failed (no formatted code in response for input '$snippet1')")
+      }
+      assert(formattedCode1 == formattedSnippet1)
+
+      val resp2 = formattedCodeMap.getOrElse(
+        "cell2",
+        sys.error("No data for key 'cell2' in response")
+      )
+      assert(resp2.initial_code == snippet2)
+      val formattedCode2 = resp2.code.getOrElse {
+        sys.error(s"Formatting failed (no formatted code in response for input '$snippet2')")
+      }
+      assert(formattedCode2 == formattedSnippet2)
+    }
+
+  }
+
+}

--- a/modules/shared/protocol/src/main/scala/almond/protocol/custom/Format.scala
+++ b/modules/shared/protocol/src/main/scala/almond/protocol/custom/Format.scala
@@ -1,0 +1,38 @@
+package almond.protocol.custom
+
+import java.nio.charset.StandardCharsets
+
+import almond.protocol.{MessageType, RawJson}
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+import scala.collection.immutable.ListMap
+
+object Format {
+
+  final case class Request(
+    cells: ListMap[String, String],
+    conf: RawJson = RawJson.emptyObj
+  )
+
+  final case class Response(
+    key: String,
+    initial_code: String,
+    code: Option[String] = None
+  )
+
+  final case class Reply()
+
+
+  def requestType = MessageType[Request]("format_request")
+  def responseType = MessageType[Response]("format_response")
+  def replyType = MessageType[Reply]("format_reply")
+
+  implicit val requestCodec: JsonValueCodec[Request] =
+    JsonCodecMaker.make
+  implicit val responseCodec: JsonValueCodec[Response] =
+    JsonCodecMaker.make
+  implicit val replyCodec: JsonValueCodec[Reply] =
+    JsonCodecMaker.make
+
+}

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -9,6 +9,7 @@ object Deps {
     def ammonite = "2.2.0-4-4bd225e"
     def caseApp = "2.0.4"
     def jsoniterScala = "2.6.0"
+    def scalafmt = "2.6.4"
   }
 
   def ammoniteRepl = setting(("com.lihaoyi" % "ammonite-repl" % Versions.ammonite).cross(CrossVersion.full))
@@ -26,6 +27,7 @@ object Deps {
   def jsoniterScalaMacros = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % Versions.jsoniterScala
   def jvmRepr = "com.github.jupyter" % "jvm-repr" % "0.4.0"
   def metabrowseServer = "org.scalameta" %% "metabrowse-server" % "0.2.3"
+  def scalafmtDynamic = "org.scalameta" %% "scalafmt-dynamic" % Versions.scalafmt
   def scalaReflect = setting("org.scala-lang" % "scala-reflect" % scalaVersion.value)
   def scalaRx = "com.lihaoyi" %% "scalarx" % "0.4.3"
   def scalatags = "com.lihaoyi" %% "scalatags" % "0.9.1"


### PR DESCRIPTION
This adds handlers for `format_request` messages, sent by the [`@almond-sh/scalafmt` extension](https://github.com/almond-sh/almond-scalafmt), allowing one to format one or all cells in almond notebooks from JupyterLab.

~Not tested against the [published version](https://www.npmjs.com/package/@almond-sh/scalafmt) of `@almond-sh/scalafmt` yet.~