### PR TITLE
Use async polling to update the front-end for spark progress bar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -247,6 +247,7 @@ lazy val `almond-spark` = project
     mimaExceptIn("2.13"),
     libraryDependencies ++= Seq(
       Deps.ammoniteReplApi.value % "provided",
+      Deps.fs2,
       Deps.ammoniteSpark,
       Deps.jsoniterScalaCore,
       Deps.jsoniterScalaMacros % Provided,

--- a/build.sbt
+++ b/build.sbt
@@ -247,7 +247,6 @@ lazy val `almond-spark` = project
     mimaExceptIn("2.13"),
     libraryDependencies ++= Seq(
       Deps.ammoniteReplApi.value % "provided",
-      Deps.fs2,
       Deps.ammoniteSpark,
       Deps.jsoniterScalaCore,
       Deps.jsoniterScalaMacros % Provided,


### PR DESCRIPTION
Spark progress bar front end's updates and polled once a second instead of pushed by each task start/end.

Should fix #448 

Tested using
```
spark.range(10000000).repartition(5000).count
```
Works both locally and on a cluster with typical spark jobs.