### PR TITLE
Add Deepnote to Try it section in the Docs

### DIFF
--- a/docs/pages/try-deepnote.md
+++ b/docs/pages/try-deepnote.md
@@ -1,0 +1,8 @@
+---
+title: deepnote
+---
+
+You can also try Almond very quickly by cloning [this Deepnote project with Almond kernel and examples](https://deepnote.com/project/9970220b-94df-4e6e-9695-85dda6b14c59#%2Fexamples%2Fnotebooks%2Findex.ipynb). Deepnote offers hosted notebooks with real-time collaboration capabilities for free.
+
+
+[![Launch in Deepnote](https://deepnote.com/buttons/launch-in-deepnote.svg)](https://deepnote.com/project/9970220b-94df-4e6e-9695-85dda6b14c59#%2Fexamples%2Fnotebooks%2Findex.ipynb)

--- a/docs/website/sidebars.json
+++ b/docs/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Intro": ["intro"],
-    "Try it": ["try-mybinder", "try-docker"],
+    "Try it": ["try-mybinder", "try-docker", "try-deepnote"],
     "Installation": ["quick-start-install", "install-options", "install-multiple", "install-versions", "install-other"],
     "Usage": ["usage-plotting", "usage-spark"],
     "User API": ["api", "api-ammonite", "api-jupyter", "api-access-instances"],


### PR DESCRIPTION
Hi, Deepnote just added a possibility to install custom environments and also documented usage with Almond. I'd say it's a pretty good addition to Binder and NBviewer ;)

Disclaimer: I am a core member of Deepnote team.