### PR TITLE
Fix import error

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/amm/AlmondPreprocessor.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/amm/AlmondPreprocessor.scala
@@ -160,6 +160,7 @@ class AlmondPreprocessor(
         Some(extraCode0)
       } else
         None
+    case(_, _, t: G#Import) => None
     case (_, code, t) =>
       val ident = code
       val extraCode0 =
@@ -186,7 +187,7 @@ class AlmondPreprocessor(
         (resOpt, extraOpt) match {
           case (None, _) => None
           case (Some(res), None) => Some(res)
-          case (Some(res), Some(extra)) => Some(res)
+          case (Some(res), Some(extra)) =>
             Some(res.copy(printer = s"{ $extra; Iterator() }" +: res.printer))
         }
       }

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaInterpreterTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaInterpreterTests.scala
@@ -437,6 +437,9 @@ object ScalaInterpreterTests extends TestSuite {
         .assertSuccess()
       val Seq(after2) = outputHandler.displayed()
       assert(after2.text == """[{"varName":"n","varSize":"","varShape":"","varContent":"2","varType":"Int","isMatrix":false},{"varName":"m","varSize":"","varShape":"","varContent":"4","varType":"Int","isMatrix":false}]""")
+
+      interpreter.execute("import scala.collection.mutable")
+        .assertSuccess()
     }
   }
 


### PR DESCRIPTION
This fix the error occurs when running any import statement with variable inspector enabled.
```scala
import scala.util.Properties
```

```
cmd0.sc:7: not found: value res0
  .declareVariable("res0", res0); Iterator() },
                           ^Compilation Failed

Compilation Failed
```