### PR TITLE
Prevent omitting empty `matches` field from `complete_reply` during json serialization

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/amm/AlmondPreprocessor.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/amm/AlmondPreprocessor.scala
@@ -160,7 +160,7 @@ class AlmondPreprocessor(
         Some(extraCode0)
       } else
         None
-    case(_, _, t: G#Import) => None
+    case (_, _, t: G#Import) => None
     case (_, code, t) =>
       val ident = code
       val extraCode0 =

--- a/modules/shared/protocol/src/main/scala/almond/protocol/Complete.scala
+++ b/modules/shared/protocol/src/main/scala/almond/protocol/Complete.scala
@@ -43,6 +43,6 @@ object Complete {
   implicit val requestCodec: JsonValueCodec[Request] =
     JsonCodecMaker.make
   implicit val replyCodec: JsonValueCodec[Reply] =
-    JsonCodecMaker.make
+    JsonCodecMaker.makeWithRequiredCollectionFields
 
 }

--- a/modules/shared/protocol/src/test/scala/almond/protocol/ProtocolTests.scala
+++ b/modules/shared/protocol/src/test/scala/almond/protocol/ProtocolTests.scala
@@ -19,6 +19,19 @@ object ProtocolTests extends TestSuite {
         assert(result == expected)
       }
     }
+
+    test("complete_reply") {
+      test("preserve matches field in json reply even if no match found") {
+        val reply = Complete.Reply(
+          matches = Nil,
+          cursor_start = 0,
+          cursor_end = 7,
+          metadata = RawJson.emptyObj
+        )
+        val json = writeToString(reply)
+        assert(json.contains(""""matches":[]"""))
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Fix the issue when doing completion and there are no matches, the `matches` field is omitted from the reply message during json serialization, so for example returns
```json
{"cursor_start":7,"cursor_end":7,"metadata":{},"status":"ok"}
```
instead of the correct
```json
{"matches":[],"cursor_start":7,"cursor_end":7,"metadata":{},"status":"ok"}
```

Discovered when I was using jupyter console, might cause problems with other jupyter clients as well.

On an unrelated note, also add the white space I missed in my previous PR. Doesn't affect anything, but kinda trips me a little bit once I've noticed it...