### PR TITLE
Add missing explicit main class

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -229,6 +229,7 @@ class ScalaKernel(val crossScalaVersion: String) extends AlmondModule with Exter
       Name.IMPLEMENTATION_VENDOR.toString -> "sh.almond"
     )
   }
+  def mainClass = Some("almond.ScalaKernel")
 }
 
 // For Scala 3 only. This publishes modules like scala-kernel_3.0.2 that


### PR DESCRIPTION
Without this, I'm getting
```
scala.scala-kernel[2.12.16].finalMainClass No main class specified or found
```
when running
```
$ ./mill -i 'scala.scala-kernel[2.12.16].launcher'
```