### PR TITLE
Bump jansi to 2.4.0

### DIFF
--- a/modules/scala/scala-interpreter/src/main/java/almond/internals/AnsiToHtmlProcessor.java
+++ b/modules/scala/scala-interpreter/src/main/java/almond/internals/AnsiToHtmlProcessor.java
@@ -68,11 +68,18 @@ public class AnsiToHtmlProcessor extends AnsiProcessor {
 
     @Override
     protected void processSetForegroundColor(int color, boolean bright) throws IOException {
-        haos.writeAttribute("span style=\"color: " + HtmlAnsiOutputStream.ANSI_COLOR_MAP[color] + ";\"");
+        // hard-coded color are for nteract (where the ansi-* classes are defined), and it might be useful from nbviewer too
+        // ansi-* classes are for jupyterlab (and classic too I think)
+        haos.writeAttribute("span style=\"color: " + HtmlAnsiOutputStream.RGB_COLOR_MAP[color] + "\"");
+        haos.writeAttribute("span class=\"ansi-" + HtmlAnsiOutputStream.ANSI_COLOR_MAP[color] + "-fg\"");
     }
 
     @Override
     protected void processSetBackgroundColor(int color, boolean bright) throws IOException {
-        haos.writeAttribute("span style=\"background-color: " + HtmlAnsiOutputStream.ANSI_COLOR_MAP[color] + ";\"");
+        String extra = "";
+        if (color == 7)
+            extra = "; color: rgb(255, 255, 255);";
+        haos.writeAttribute("span style=\"background-color: " + HtmlAnsiOutputStream.RGB_COLOR_MAP[color] + extra + "\"");
+        haos.writeAttribute("span class=\"ansi-" + HtmlAnsiOutputStream.ANSI_COLOR_MAP[color] + "-bg\"");
     }
 }

--- a/modules/scala/scala-interpreter/src/main/java/almond/internals/AnsiToHtmlProcessor.java
+++ b/modules/scala/scala-interpreter/src/main/java/almond/internals/AnsiToHtmlProcessor.java
@@ -1,0 +1,73 @@
+// adapted from https://github.com/Osiris-Team/jansi/blob/3a832dfc0c4bd9d00de356dbac0f0fbaebf75786/src/main/java/org/fusesource/jansi/io/AnsiToHtmlProcessor.java
+// see: https://github.com/fusesource/jansi/pull/212
+
+package almond.internals;
+
+import org.fusesource.jansi.io.AnsiProcessor;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class AnsiToHtmlProcessor extends AnsiProcessor {
+    private boolean concealOn = false;
+    private HtmlAnsiOutputStream haos;
+
+    AnsiToHtmlProcessor(OutputStream os) {
+        super(os);
+    }
+
+    public HtmlAnsiOutputStream getHtmlAnsiOutputStream() {
+        return haos;
+    }
+
+    public void setHtmlAnsiOutputStream(HtmlAnsiOutputStream haos) {
+        this.haos = haos;
+    }
+
+    @Override
+    protected void processSetAttribute(int attribute) throws IOException {
+        switch (attribute) {
+            case ATTRIBUTE_CONCEAL_ON:
+                haos.write("\u001B[8m");
+                concealOn = true;
+                break;
+            case ATTRIBUTE_INTENSITY_BOLD:
+                haos.writeAttribute("b");
+                break;
+            case ATTRIBUTE_INTENSITY_NORMAL:
+                haos.closeAttributes();
+                break;
+            case ATTRIBUTE_UNDERLINE:
+                haos.writeAttribute("u");
+                break;
+            case ATTRIBUTE_UNDERLINE_OFF:
+                haos.closeAttributes();
+                break;
+            case ATTRIBUTE_NEGATIVE_ON:
+                break;
+            case ATTRIBUTE_NEGATIVE_OFF:
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    protected void processAttributeReset() throws IOException {
+        if (concealOn) {
+            haos.write("\u001B[0m");
+            concealOn = false;
+        }
+        haos.closeAttributes();
+    }
+
+    @Override
+    protected void processSetForegroundColor(int color, boolean bright) throws IOException {
+        haos.writeAttribute("span style=\"color: " + HtmlAnsiOutputStream.ANSI_COLOR_MAP[color] + ";\"");
+    }
+
+    @Override
+    protected void processSetBackgroundColor(int color, boolean bright) throws IOException {
+        haos.writeAttribute("span style=\"background-color: " + HtmlAnsiOutputStream.ANSI_COLOR_MAP[color] + ";\"");
+    }
+}

--- a/modules/scala/scala-interpreter/src/main/java/almond/internals/AnsiToHtmlProcessor.java
+++ b/modules/scala/scala-interpreter/src/main/java/almond/internals/AnsiToHtmlProcessor.java
@@ -53,6 +53,11 @@ public class AnsiToHtmlProcessor extends AnsiProcessor {
     }
 
     @Override
+    protected void processDefaultTextColor() throws IOException {
+        processAttributeReset();
+    }
+
+    @Override
     protected void processAttributeReset() throws IOException {
         if (concealOn) {
             haos.write("\u001B[0m");

--- a/modules/scala/scala-interpreter/src/main/java/almond/internals/HtmlAnsiOutputStream.java
+++ b/modules/scala/scala-interpreter/src/main/java/almond/internals/HtmlAnsiOutputStream.java
@@ -63,6 +63,8 @@ public class HtmlAnsiOutputStream extends AnsiOutputStream {
 
     public static final String[] ANSI_COLOR_MAP = {"black", "red",
             "green", "yellow", "blue", "magenta", "cyan", "white",};
+    public static final String[] RGB_COLOR_MAP = {"black", "red",
+            "rgb(0, 187, 0)", "yellow", "blue", "magenta", "rgb(0, 187, 187)", "white",};
 
     private static final byte[] BYTES_QUOT = "&quot;".getBytes();
     private static final byte[] BYTES_AMP = "&amp;".getBytes();

--- a/modules/scala/scala-interpreter/src/main/java/almond/internals/HtmlAnsiOutputStream.java
+++ b/modules/scala/scala-interpreter/src/main/java/almond/internals/HtmlAnsiOutputStream.java
@@ -1,18 +1,59 @@
-
-// adapted from https://github.com/fusesource/jansi/blob/70ff98d5cbd5fb005d8a44ed31050388b256f9c6/jansi/src/main/java/org/fusesource/jansi/HtmlAnsiOutputStream.java
+// adapted from https://github.com/Osiris-Team/jansi/blob/3a832dfc0c4bd9d00de356dbac0f0fbaebf75786/src/main/java/org/fusesource/jansi/io/HtmlAnsiOutputStream.java
+// see: https://github.com/fusesource/jansi/pull/212
 
 package almond.internals;
 
-import org.fusesource.jansi.AnsiOutputStream;
+import org.fusesource.jansi.io.AnsiOutputStream;
+
+/*
+ * Copyright (C) 2009-2017 the original author(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.fusesource.jansi.AnsiColors;
+import org.fusesource.jansi.AnsiMode;
+import org.fusesource.jansi.AnsiType;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * A optimized/edited {@link HtmlAnsiOutputStream} for ansi 2.x and above. <br>
+ * @author <a href="https://github.com/Osiris-Team">Osiris Team</a>
+ * @author <a href="http://code.dblock.org">Daniel Doubrovkine</a>
+ */
 public class HtmlAnsiOutputStream extends AnsiOutputStream {
 
-    private boolean concealOn = false;
+    private static final Map<OutputStream, AnsiToHtmlProcessor> streamsAndProcessors = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a new {@link AnsiToHtmlProcessor} for the provided {@link OutputStream}, <br>
+     * and adds both to the {@link #streamsAndProcessors} map. <br>
+     * This is done to have working multithreading and diminish the need of a getProcessor() method <br>
+     * in the {@link AnsiOutputStream}.
+     */
+    private static synchronized AnsiToHtmlProcessor createAnsiToHtmlProcessorForOutput(OutputStream out){
+        AnsiToHtmlProcessor processor = new AnsiToHtmlProcessor(out);
+        streamsAndProcessors.put(out, processor);
+        return processor;
+    }
 
     @Override
     public void close() throws IOException {
@@ -20,10 +61,8 @@ public class HtmlAnsiOutputStream extends AnsiOutputStream {
         super.close();
     }
 
-    private static final String[] ANSI_COLOR_MAP = {"black", "red",
+    public static final String[] ANSI_COLOR_MAP = {"black", "red",
             "green", "yellow", "blue", "magenta", "cyan", "white",};
-    private static final String[] RGB_COLOR_MAP = {"black", "red",
-            "rgb(0, 187, 0)", "yellow", "blue", "magenta", "rgb(0, 187, 187)", "white",};
 
     private static final byte[] BYTES_QUOT = "&quot;".getBytes();
     private static final byte[] BYTES_AMP = "&amp;".getBytes();
@@ -31,21 +70,36 @@ public class HtmlAnsiOutputStream extends AnsiOutputStream {
     private static final byte[] BYTES_GT = "&gt;".getBytes();
 
     public HtmlAnsiOutputStream(OutputStream os) {
-        super(os);
+        super(os,
+                new WidthSupplier() {
+                    @Override
+                    public int getTerminalWidth() {
+                        return Integer.MAX_VALUE;
+                    }
+                },
+                AnsiMode.Default,
+                createAnsiToHtmlProcessorForOutput(os),
+                AnsiType.Native,
+                AnsiColors.Colors16,
+                Charset.defaultCharset(),
+                null,
+                null,
+                true);
+        streamsAndProcessors.get(os).setHtmlAnsiOutputStream(this);
     }
 
-    private final List<String> closingAttributes = new ArrayList<String>();
+    private final List<String> closingAttributes = new ArrayList<>();
 
-    private void write(String s) throws IOException {
+    public void write(String s) throws IOException {
         super.out.write(s.getBytes());
     }
 
-    private void writeAttribute(String s) throws IOException {
+    public void writeAttribute(String s) throws IOException {
         write("<" + s + ">");
         closingAttributes.add(0, s.split(" ", 2)[0]);
     }
 
-    private void closeAttributes() throws IOException {
+    public void closeAttributes() throws IOException {
         for (String attr : closingAttributes) {
             write("</" + attr + ">");
         }
@@ -74,64 +128,5 @@ public class HtmlAnsiOutputStream extends AnsiOutputStream {
     public void writeLine(byte[] buf, int offset, int len) throws IOException {
         write(buf, offset, len);
         closeAttributes();
-    }
-
-    @Override
-    protected void processSetAttribute(int attribute) throws IOException {
-        switch (attribute) {
-            case ATTRIBUTE_CONCEAL_ON:
-                write("\u001B[8m");
-                concealOn = true;
-                break;
-            case ATTRIBUTE_INTENSITY_BOLD:
-                writeAttribute("b");
-                break;
-            case ATTRIBUTE_INTENSITY_NORMAL:
-                closeAttributes();
-                break;
-            case ATTRIBUTE_UNDERLINE:
-                writeAttribute("u");
-                break;
-            case ATTRIBUTE_UNDERLINE_OFF:
-                closeAttributes();
-                break;
-            case ATTRIBUTE_NEGATIVE_ON:
-                break;
-            case ATTRIBUTE_NEGATIVE_OFF:
-                break;
-            default:
-                break;
-        }
-    }
-
-    @Override
-    protected void processAttributeRest() throws IOException {
-        if (concealOn) {
-            write("\u001B[0m");
-            concealOn = false;
-        }
-        closeAttributes();
-    }
-
-    @Override
-    protected void processDefaultTextColor() throws IOException {
-        processAttributeRest();
-    }
-
-    @Override
-    protected void processSetForegroundColor(int color, boolean bright) throws IOException {
-        // hard-coded color are for nteract (where the ansi-* classes are defined), and it might be useful from nbviewer too
-        // ansi-* classes are for jupyterlab (and classic too I think)
-        writeAttribute("span style=\"color: " + RGB_COLOR_MAP[color] + "\"");
-        writeAttribute("span class=\"ansi-" + ANSI_COLOR_MAP[color] + "-fg\"");
-    }
-
-    @Override
-    protected void processSetBackgroundColor(int color, boolean bright) throws IOException {
-        String extra = "";
-        if (color == 7)
-            extra = "; color: rgb(255, 255, 255);";
-        writeAttribute("span style=\"background-color: " + RGB_COLOR_MAP[color] + extra + "\"");
-        writeAttribute("span class=\"ansi-" + ANSI_COLOR_MAP[color] + "-bg\"");
     }
 }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -44,7 +44,7 @@ object Deps {
   def coursierApi              = ivy"io.get-coursier:interface:1.0.9"
   def directories              = ivy"io.github.soc:directories:12"
   def fs2                      = ivy"co.fs2::fs2-core:2.5.11"
-  def jansi                    = ivy"org.fusesource.jansi:jansi:1.18"
+  def jansi                    = ivy"org.fusesource.jansi:jansi:2.4.0"
   def jeromq                   = ivy"org.zeromq:jeromq:0.5.2"
   def jsoniterScalaCore        = ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:${Versions.jsoniterScala}"
   def jsoniterScalaMacros      = ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:${Versions.jsoniterScala}"


### PR DESCRIPTION
Almond uses jansi's `HtmlAnsiOutputStream` to convert the ammonite's output (ansi) to Jupyter output (HTML)

However, jansi dropped HtmlAnsiOutputStream support (at least from 2.0.0), and the API of AnsiOutputStream has quite changed. see: https://github.com/fusesource/jansi/issues/210

This commit adopt the jansi v2 compatible HtmlAnsiOutputStream implementation from https://github.com/fusesource/jansi/pull/212 Even though the PR isn't merged because the maintainer doesn't believe there's no demand on HtmlAnsiOutputStream, but the code seems legit, and I believe we can safe to use that implementation.