### PR TITLE
Add New Option '--use-thread-interrupt'

### DIFF
--- a/docs/pages/install-options.md
+++ b/docs/pages/install-options.md
@@ -125,6 +125,9 @@ Sets the kernel log level. Can be any of
 
 #### `--special-loader`
 
+#### `--use-thread-interrupt`
+
+Whether to use 'Thread.interrupt' method or deprecated 'Thread.stop' method (default) when interrupting kernel.
 
 ## Jupyter-related
 

--- a/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
@@ -31,7 +31,8 @@ final class Execute(
   logCtx: LoggerContext,
   updateBackgroundVariablesEcOpt: Option[ExecutionContext],
   commHandlerOpt: => Option[CommHandler],
-  silent: Ref[Boolean]
+  silent: Ref[Boolean],
+  useThreadInterrupt: Boolean
 ) {
 
   private val log = logCtx(getClass)
@@ -177,7 +178,13 @@ final class Execute(
           case Some(t) =>
             interruptedStackTraceOpt0 = Some(t.getStackTrace)
             log.debug(s"Received SIGINT, stopping thread $t\n${interruptedStackTraceOpt0.map("  " + _).mkString("\n")}")
-            t.stop()
+            if (useThreadInterrupt) {
+              log.debug(s"Calling 'Thread.interrupt'")
+              t.interrupt()
+            } else {
+              log.debug(s"Calling 'Thread.stop'")
+              t.stop()
+            }
         }
       }.apply {
         t
@@ -193,7 +200,13 @@ final class Execute(
         log.warn("Interrupt asked, but no execution is running")
       case Some(t) =>
         log.debug(s"Interrupt asked, stopping thread $t\n${t.getStackTrace.map("  " + _).mkString("\n")}")
-        t.stop()
+        if (useThreadInterrupt) {
+          log.debug(s"Calling 'Thread.interrupt'")
+          t.interrupt()
+        } else {
+          log.debug(s"Calling 'Thread.stop'")
+          t.stop()
+        }
     }
 
 

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -56,7 +56,8 @@ final class ScalaInterpreter(
     logCtx,
     params.updateBackgroundVariablesEcOpt,
     commHandlerOpt,
-    silent0
+    silent0,
+    params.useThreadInterrupt
   )
 
 

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreterParams.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreterParams.scala
@@ -32,5 +32,6 @@ final case class ScalaInterpreterParams(
   disableCache: Boolean = false,
   autoUpdateLazyVals: Boolean = true,
   autoUpdateVars: Boolean = true,
-  allowVariableInspector: Option[Boolean] = None
+  allowVariableInspector: Option[Boolean] = None,
+  useThreadInterrupt: Boolean = false
 )

--- a/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
@@ -56,7 +56,9 @@ final case class Options(
   @HelpMessage("Whether to enable variable inspector")
     variableInspector: Option[Boolean] = None,
   @HelpMessage("Whether to process format requests with scalafmt")
-    scalafmt: Boolean = true
+    scalafmt: Boolean = true,
+  @HelpMessage("Whether to use 'Thread.interrupt' method or deprecated 'Thread.stop' method (default) when interrupting kernel.")
+  useThreadInterrupt: Boolean = false
 ) {
 
   private lazy val sbv = scala.util.Properties.versionNumberString.split('.').take(2).mkString(".")

--- a/modules/scala/scala-kernel/src/main/scala/almond/ScalaKernel.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/ScalaKernel.scala
@@ -128,7 +128,8 @@ object ScalaKernel extends CaseApp[Options] {
         disableCache = options.disableCache,
         autoUpdateLazyVals = options.autoUpdateLazyVals,
         autoUpdateVars = options.autoUpdateVars,
-        allowVariableInspector = options.variableInspector
+        allowVariableInspector = options.variableInspector,
+        useThreadInterrupt = options.useThreadInterrupt
       ),
       logCtx = logCtx
     )


### PR DESCRIPTION
  - Added new boolean option '--use-thread-interrupt' for allowing kernel to be interrupted using 'Thread.interrupt' method rather than deprecated 'Thread.stop' method. For backward compatibility, default value of this option is 'false', i.e. 'Thread.stop' is used when option is not specified or set to 'false'
  - Added entry in documentation for new option
  - Ran test suite to ensure default interrupt behavior of kernel is preserved