### PR TITLE
Set iopub socket hwm to 0

### DIFF
--- a/modules/shared/channels/src/main/scala/almond/channels/zeromq/ZeromqSocketImpl.scala
+++ b/modules/shared/channels/src/main/scala/almond/channels/zeromq/ZeromqSocketImpl.scala
@@ -56,6 +56,10 @@ final class ZeromqSocketImpl(
   channel.setLinger(1000)
   if (socketType == SocketType.ROUTER)
     channel.setRouterHandover(true)
+  if (socketType == SocketType.PUB) {
+    // If publisher's socket queue gets filled, all new messages are dropped; remove queue size constraint
+    channel.setHWM(0)
+  }
 
   @volatile private var opened = false
   @volatile private var closed = false


### PR DESCRIPTION
This PR aims to provide a fix for this issue https://github.com/almond-sh/almond/issues/1061 
MQ has a concept of [high water mark](http://api.zeromq.org/3-2:zmq-setsockopt): the maximal number of messages that may be queued on socket. If the queue is full, either new messages are dropped or the socket becomes blocked. The default value for HWM is 1000. If iopub message rate is too high, the new messages are dropped (and for whatever reason the kernel blocks at this moment, see the issue for more details).

Setting HWM to 0 resolves that problem. The only possible downside of this is that the kernel might crash due to OOM if it produces too much output too quickly, but it doesn't seem a huge issue to me.