### PR TITLE
Temporarily rely on interp.load.cp to back %AddJar

### DIFF
--- a/modules/scala/toree-hooks/src/main/scala/almond/toree/LineMagicHandlers.scala
+++ b/modules/scala/toree-hooks/src/main/scala/almond/toree/LineMagicHandlers.scala
@@ -75,7 +75,13 @@ object LineMagicHandlers {
             System.err.println(s"Warning: ignoring unsupported %AddJar argument --magic")
           if (uri.getScheme == "file") {
             val path = Paths.get(uri)
-            Right(s"import $$cp.`$path`")
+            val q    = "\""
+            Right(s"interp.load.cp(os.Path($q$q$q$path$q$q$q))")
+          }
+          else if (uri.getScheme == "http" || uri.getScheme == "https") {
+            val file = coursierapi.Cache.create().get(coursierapi.Artifact.of(uri.toASCIIString))
+            val q    = "\""
+            Right(s"interp.load.cp(os.Path($q$q$q$file$q$q$q))")
           }
           else {
             System.err.println(


### PR DESCRIPTION
`import $cp` would be better, as it ensures the class path is updated prior to compiling and running the current cell. But we need com-lihaoyi/Ammonite#1340 to make it work.