### PR TITLE
Run non-Java 8 job on Java 17 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             JDK: 8
             SCALA: 2.13.10
           - OS: ubuntu-latest
-            JDK: 11
+            JDK: 17
             SCALA: 2.12.17
     steps:
     - name: Don't convert LF to CRLF during checkout


### PR DESCRIPTION
Rather than Java 11