### PR TITLE
Add two-step startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         apps:
     - run: ./mill -i scala.integration.test
 
-  windows-tests:
+  windows-integration-tests:
     runs-on: windows-latest
     steps:
     - name: Don't convert LF to CRLF during checkout
@@ -189,7 +189,7 @@ jobs:
   # job whose name doesn't change when we bump Scala versions, add OSes, …
   # We require this job for auto-merge.
   all-tests:
-    needs: [examples, bincompat, test, integration-tests, windows-tests, website, publishLocal]
+    needs: [examples, bincompat, test, integration-tests, windows-integration-tests, website, publishLocal]
     runs-on: ubuntu-latest
     steps:
     - run: true

--- a/build.sc
+++ b/build.sc
@@ -569,11 +569,10 @@ trait Integration extends SbtModule {
     )
 
     // based on https://github.com/com-lihaoyi/mill/blob/cfbafb806351c3e1664de4e2001d3d1ddda045da/scalalib/src/TestModule.scala#L98-L164
-    def testCommand: T[Map[String, Seq[String]]] =
-      T.task {
+    def testCommand(args: String*) =
+      T.command {
         import mill.testrunner.TestRunner
 
-        val args          = Nil
         val globSelectors = Nil
         val outputPath    = os.pwd / "test-output.json"
         val useArgsFile   = testUseArgsFile()

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelLauncher.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelLauncher.scala
@@ -240,8 +240,10 @@ class KernelLauncher(isTwoStepStartup: Boolean, defaultScalaVersion: String) {
 
         t.start()
         try f(sess)
-        finally
+        finally {
           running = false
+          close()
+        }
       }
 
       private def runnerSession(

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelLauncher.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelLauncher.scala
@@ -343,8 +343,13 @@ class KernelLauncher(isTwoStepStartup: Boolean, defaultScalaVersion: String) {
         if (proc != null) {
           if (proc.isAlive()) {
             proc.close()
-            if (!proc.waitFor(3.seconds.toMillis))
+            val timeout = 3.seconds
+            if (!proc.waitFor(timeout.toMillis)) {
+              System.err.println(
+                s"Test kernel still running after $timeout, destroying it forcibly"
+              )
               proc.destroyForcibly()
+            }
           }
           proc = null
         }

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelLauncher.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelLauncher.scala
@@ -343,8 +343,7 @@ class KernelLauncher(isTwoStepStartup: Boolean, defaultScalaVersion: String) {
         if (proc != null) {
           if (proc.isAlive()) {
             proc.close()
-            proc.waitFor(3.seconds.toMillis)
-            if (proc.isAlive())
+            if (!proc.waitFor(3.seconds.toMillis))
               proc.destroyForcibly()
           }
           proc = null

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelTestsDefinitions.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelTestsDefinitions.scala
@@ -2,9 +2,12 @@ package almond.integration
 
 import almond.testkit.Dsl._
 
-abstract class KernelTestsDefinitions(scalaVersion: String) extends munit.FunSuite {
+abstract class KernelTestsDefinitions(
+  scalaVersion: String,
+  isTwoStepStartup: Boolean
+) extends munit.FunSuite {
 
-  val kernelLauncher = new KernelLauncher(scalaVersion)
+  val kernelLauncher = new KernelLauncher(isTwoStepStartup = isTwoStepStartup, scalaVersion)
 
   test("jvm-repr") {
     kernelLauncher.withKernel { implicit runner =>

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelTestsSimple212.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelTestsSimple212.scala
@@ -1,3 +1,3 @@
 package almond.integration
 
-class KernelTestsSimple212 extends KernelTestsDefinitions("2.12.17")
+class KernelTestsSimple212 extends KernelTestsDefinitions("2.12.17", isTwoStepStartup = false)

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelTestsSimple213.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelTestsSimple213.scala
@@ -1,3 +1,3 @@
 package almond.integration
 
-class KernelTestsSimple213 extends KernelTestsDefinitions("2.13.10")
+class KernelTestsSimple213 extends KernelTestsDefinitions("2.13.10", isTwoStepStartup = false)

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelTestsSimple3.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelTestsSimple3.scala
@@ -1,3 +1,3 @@
 package almond.integration
 
-class KernelTestsSimple3 extends KernelTestsDefinitions("3.2.2")
+class KernelTestsSimple3 extends KernelTestsDefinitions("3.2.2", isTwoStepStartup = false)

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup.scala
@@ -1,0 +1,102 @@
+package almond.integration
+
+import almond.integration.Tests.ls
+import almond.testkit.Dsl._
+
+class KernelTestsTwoStepStartup extends munit.FunSuite {
+
+  val kernelLauncher = new KernelLauncher(isTwoStepStartup = true, "2.13.10")
+
+  test("Directives and code in first cell 3") {
+    kernelLauncher.withKernel { implicit runner =>
+      implicit val sessionId: SessionId = SessionId()
+      runner.withSession() { implicit session =>
+        execute(
+          """//> using scala "3.2.2"
+            |import scala.compiletime.ops.*
+            |val sv = scala.util.Properties.versionNumberString
+            |""".stripMargin,
+          "import scala.compiletime.ops.*" + ls + ls +
+            """sv: String = "2.13.10""""
+        )
+      }
+    }
+  }
+
+  test("Directives and code in first cell 213") {
+    kernelLauncher.withKernel { implicit runner =>
+      implicit val sessionId: SessionId = SessionId()
+      runner.withSession() { implicit session =>
+        execute(
+          """//> using scala "2.13.10"
+            |val sv = scala.util.Properties.versionNumberString
+            |""".stripMargin,
+          """sv: String = "2.13.10""""
+        )
+      }
+    }
+  }
+
+  test("Directives and code in first cell 212") {
+    kernelLauncher.withKernel { implicit runner =>
+      implicit val sessionId: SessionId = SessionId()
+      runner.withSession() { implicit session =>
+        execute(
+          """//> using scala "2.12.17"
+            |val sv = scala.util.Properties.versionNumberString
+            |""".stripMargin,
+          """sv: String = "2.12.17""""
+        )
+      }
+    }
+  }
+
+  test("Directives and code in first cell short 213") {
+    kernelLauncher.withKernel { implicit runner =>
+      implicit val sessionId: SessionId = SessionId()
+      runner.withSession() { implicit session =>
+        execute(
+          """//> using scala "2.13"
+            |val sv = scala.util.Properties.versionNumberString
+            |""".stripMargin,
+          """sv: String = "2.13.10""""
+        )
+      }
+    }
+  }
+
+  test("Directives and code in first cell short 212") {
+    kernelLauncher.withKernel { implicit runner =>
+      implicit val sessionId: SessionId = SessionId()
+      runner.withSession() { implicit session =>
+        execute(
+          """//> using scala "2.12"
+            |val sv = scala.util.Properties.versionNumberString
+            |""".stripMargin,
+          """sv: String = "2.12.17""""
+        )
+      }
+    }
+  }
+
+  test("Several directives and comments") {
+    kernelLauncher.withKernel { implicit runner =>
+      implicit val sessionId: SessionId = SessionId()
+      runner.withSession() { implicit session =>
+        execute(
+          """//> using scala "3.2.2"""",
+          ""
+        )
+        execute(
+          """//> using javaOpt "-Dfoo=bar"""",
+          ""
+        )
+        execute(
+          """val foo = sys.props("foo")""",
+          """foo: String = "bar""""
+        )
+      }
+    }
+  }
+
+}

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup212.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup212.scala
@@ -1,0 +1,4 @@
+package almond.integration
+
+class KernelTestsTwoStepStartup212
+    extends KernelTestsDefinitions("2.12.17", isTwoStepStartup = true)

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup213.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup213.scala
@@ -1,0 +1,4 @@
+package almond.integration
+
+class KernelTestsTwoStepStartup213
+    extends KernelTestsDefinitions("2.13.10", isTwoStepStartup = true)

--- a/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup3.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup3.scala
@@ -1,0 +1,3 @@
+package almond.integration
+
+class KernelTestsTwoStepStartup3 extends KernelTestsDefinitions("3.2.2", isTwoStepStartup = true)

--- a/modules/scala/launcher/src/main/scala/almond/launcher/Launcher.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/Launcher.scala
@@ -131,8 +131,13 @@ object Launcher extends CaseApp[LauncherOptions] {
         "java"
     }
 
+    val memOptions =
+      if (params0.javaOptions.exists(_.startsWith("-Xmx"))) Nil
+      else Seq("-Xmx512m")
+
     val proc = os.proc(
       javaCommand,
+      memOptions,
       params0.javaOptions,
       "-cp",
       (options.extraStartupClassPath :+ launcher.toString)

--- a/modules/scala/launcher/src/main/scala/almond/launcher/Launcher.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/Launcher.scala
@@ -1,0 +1,256 @@
+package almond.launcher
+
+import almond.channels.{Channel, Connection, Message => RawMessage}
+import almond.channels.zeromq.ZeromqThreads
+import almond.kernel.{Kernel, KernelThreads, MessageFile}
+import almond.logger.{Level, LoggerContext}
+import almond.protocol.RawJson
+import almond.util.ThreadUtil.singleThreadedExecutionContext
+import caseapp.core.RemainingArgs
+import caseapp.core.app.CaseApp
+import cats.effect.unsafe.IORuntime
+import coursier.launcher.{BootstrapGenerator, ClassLoaderContent, ClassPathEntry, Parameters}
+import dependency.ScalaParameters
+
+import java.io.{File, FileOutputStream, PrintStream}
+import java.nio.channels.ClosedSelectorException
+
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
+
+object Launcher extends CaseApp[LauncherOptions] {
+
+  private def launchActualKernel(
+    connectionFile: String,
+    msgFileOpt: Option[os.Path],
+    currentCellCount: Int,
+    options: LauncherOptions,
+    noExecuteInputFor: Seq[String],
+    params0: LauncherParameters
+  ): Unit = {
+
+    val requestedScalaVersion = params0.scala
+      .orElse(options.scala.map(_.trim).filter(_.nonEmpty))
+      .getOrElse(Properties.defaultScalaVersion)
+
+    val scalaVersion = requestedScalaVersion match {
+      case "2.12"       => "2.12.17"
+      case "2" | "2.13" => "2.13.10"
+      case "3"          => "3.2.2"
+      case _            => requestedScalaVersion
+    }
+
+    def content(entries: Seq[(coursierapi.Artifact, File)]): ClassLoaderContent = {
+      val entries0 = entries.map {
+        case (a, _) =>
+          ClassPathEntry.Url(a.getUrl)
+      }
+      ClassLoaderContent(entries0)
+    }
+
+    val cache = coursierapi.Cache.create().withLogger(coursierapi.Logger.progressBars())
+    def fetcher = coursierapi.Fetch.create()
+      .withCache(cache)
+      .addRepositories(coursierapi.MavenRepository.of("https://jitpack.io"))
+    def fetch(
+      dep: coursierapi.Dependency,
+      extraDeps: Seq[coursierapi.Dependency] = Nil,
+      sources: Boolean = false
+    ) = {
+      var fetcher0 = fetcher
+      if (sources)
+        fetcher0 = fetcher0.addClassifiers("sources")
+      fetcher0 = fetcher0.addDependencies(dep)
+      for (dep0 <- extraDeps)
+        fetcher0 = fetcher0.addDependencies(dep0)
+      fetcher0
+        .fetchResult()
+        .getArtifacts
+        .asScala
+        .toVector
+        .map(e => (e.getKey, e.getValue))
+    }
+    val apiFiles = {
+      val scalaParams = ScalaParameters(scalaVersion)
+      val extraDeps = options.sharedDependencies.map { str =>
+        val dep = dependency.parser.DependencyParser.parse(str) match {
+          case Left(err) =>
+            sys.error(s"Malformed shared dependency '$str': $err")
+          case Right(dep0) => dep0
+        }
+
+        val javaDep = dep.applyParams(scalaParams)
+        val version = if (javaDep.version == "_") Properties.version else javaDep.version
+        coursierapi.Dependency.of(javaDep.organization, javaDep.name, version)
+      }
+      val dep = coursierapi.Dependency.of(
+        "sh.almond",
+        s"scala-kernel-api_$scalaVersion",
+        Properties.version
+      )
+      fetch(dep, extraDeps = extraDeps) ++ fetch(dep, extraDeps = extraDeps, sources = true)
+    }
+    val kernelFiles = {
+      val dep = coursierapi.Dependency.of(
+        "sh.almond",
+        s"scala-kernel_$scalaVersion",
+        Properties.version
+      )
+      val files = fetch(dep) ++ fetch(dep, sources = true)
+      files.filter {
+        val set = apiFiles.map(_._2).toSet
+        t =>
+          val f = t._2
+          !set.contains(f)
+      }
+    }
+
+    val launcher = os.temp(prefix = "almond", suffix = ".jar")
+    val params = Parameters.Bootstrap(
+      Seq(content(apiFiles), content(kernelFiles)),
+      Properties.kernelMainClass
+    )
+    BootstrapGenerator.generate(params, launcher.toNIO)
+
+    val msgFileArgs = msgFileOpt.toSeq.flatMap { msgFile =>
+      Seq[os.Shellable]("--leftover-messages", msgFile)
+    }
+    val noExecuteInputArgs = noExecuteInputFor.flatMap { id =>
+      Seq("--no-execute-input-for", id)
+    }
+
+    val javaCommand = params0.jvm.filter(_.trim.nonEmpty) match {
+      case Some(jvmId) =>
+        val jvmManager = coursierapi.JvmManager.create().setArchiveCache(
+          coursierapi.ArchiveCache.create().withCache(cache)
+        )
+        val javaHome = os.Path(jvmManager.get(jvmId), os.pwd)
+        val ext      = if (scala.util.Properties.isWin) ".exe" else ""
+        (javaHome / "bin" / s"java$ext").toString
+      case None =>
+        "java"
+    }
+
+    val proc = os.proc(
+      javaCommand,
+      params0.javaOptions,
+      "-cp",
+      (options.extraStartupClassPath :+ launcher.toString)
+        .filter(_.nonEmpty)
+        .mkString(File.pathSeparator),
+      "coursier.bootstrap.launcher.Launcher",
+      "--connection-file",
+      connectionFile,
+      "--initial-cell-count",
+      currentCellCount,
+      msgFileArgs,
+      noExecuteInputArgs,
+      options.kernelOptions
+    )
+    System.err.println(s"Launching ${proc.command.flatMap(_.value).mkString(" ")}")
+    val p = proc.spawn(stdin = os.Inherit, stdout = os.Inherit)
+    val hook: Thread =
+      new Thread("shutdown-kernel") {
+        setDaemon(true)
+        override def run(): Unit =
+          if (p.isAlive()) {
+            p.close()
+            val timeout = 100.millis
+            if (!p.waitFor(timeout.toMillis)) {
+              System.err.println(
+                s"Underlying kernel still running after $timeout, destroying it forcibly"
+              )
+              p.destroyForcibly()
+            }
+          }
+      }
+    Runtime.getRuntime.addShutdownHook(hook)
+    p.waitFor()
+    Runtime.getRuntime.removeShutdownHook(hook)
+    val exitCode = p.exitCode()
+    System.err.println(s"Sub-kernel exited with return code $exitCode")
+    if (exitCode != 0)
+      sys.exit(exitCode)
+  }
+
+  def run(options: LauncherOptions, remainingArgs: RemainingArgs): Unit = {
+
+    val logCtx = Level.fromString(options.log.getOrElse("warn")) match {
+      case Left(err) =>
+        Console.err.println(err)
+        sys.exit(1)
+      case Right(level) =>
+        options.logTo match {
+          case None =>
+            LoggerContext.stderr(level)
+          case Some(f) =>
+            LoggerContext.printStream(level, new PrintStream(new FileOutputStream(new File(f))))
+        }
+    }
+
+    val connectionFile = options.connectionFile.getOrElse {
+      Console.err.println(
+        "No connection file passed, and installation not asked. Run with --install to install the kernel, " +
+          "or pass a connection file via --connection-file to run the kernel."
+      )
+      sys.exit(1)
+    }
+
+    val colors =
+      if (options.color.getOrElse(true)) LauncherInterpreter.Colors.default
+      else LauncherInterpreter.Colors.blackWhite
+
+    val interpreterEc = singleThreadedExecutionContext("scala-launcher-interpreter")
+
+    val zeromqThreads = ZeromqThreads.create("scala-kernel-launcher")
+    val kernelThreads = KernelThreads.create("scala-kernel-launcher")
+
+    var connOpt       = Option.empty[Connection]
+    var closeExpected = false
+    val interpreter = new LauncherInterpreter(
+      connectionFile,
+      options,
+      () => {
+        val conn = connOpt.getOrElse(sys.error("No connection"))
+        closeExpected = true
+        conn.close.unsafeRunSync()(IORuntime.global)
+      }
+    )
+
+    val (run, conn) = Kernel.create(interpreter, interpreterEc, kernelThreads, logCtx)
+      .flatMap(_.runOnConnectionFileAllowClose(connectionFile, "scala", zeromqThreads, Nil))
+      .unsafeRunSync()(IORuntime.global)
+    connOpt = Some(conn)
+    val leftoverMessages: Seq[(Channel, RawMessage)] = run.unsafeRunSync()(IORuntime.global)
+
+    val leftoverMessagesFileOpt =
+      if (leftoverMessages.isEmpty) None
+      else {
+        val msgFile = MessageFile.from(leftoverMessages)
+        val leftoverMessagesFile = os.temp(
+          msgFile.asJson.value,
+          prefix = "almond-launcher-leftover-messages-",
+          suffix = ".json"
+        )
+        Some(leftoverMessagesFile)
+      }
+
+    val firstMessageIdOpt = leftoverMessages
+      .headOption
+      .collect {
+        case (Channel.Requests, m) =>
+          almond.interpreter.Message.parse[RawJson](m).toOption // FIXME Log any error on the left?
+      }
+      .flatten
+      .map(_.header.msg_id)
+
+    launchActualKernel(
+      connectionFile,
+      leftoverMessagesFileOpt,
+      interpreter.lineCount,
+      options,
+      firstMessageIdOpt.toSeq,
+      interpreter.params
+    )
+  }
+}

--- a/modules/scala/launcher/src/main/scala/almond/launcher/LauncherInterpreter.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/LauncherInterpreter.scala
@@ -1,0 +1,227 @@
+package almond.launcher
+
+import almond.interpreter.api.OutputHandler
+import almond.interpreter.{ExecuteResult, Interpreter}
+import almond.interpreter.api.DisplayData
+import almond.interpreter.input.InputManager
+import almond.protocol.KernelInfo
+
+import java.io.File
+
+import scala.cli.directivehandler._
+import scala.cli.directivehandler.EitherSequence._
+
+class LauncherInterpreter(
+  connectionFile: String,
+  options: LauncherOptions,
+  close: () => Unit
+) extends Interpreter {
+
+  def kernelInfo(): KernelInfo =
+    KernelInfo(
+      implementation = "scala",
+      implementation_version = "???",
+      language_info = KernelInfo.LanguageInfo(
+        name = "scala",
+        version = "???",
+        mimetype = "text/x-scala",
+        file_extension = ".sc",
+        nbconvert_exporter = "script",
+        codemirror_mode = Some("text/x-scala")
+      ),
+      banner =
+        s"""Almond ${"???"}
+           |Ammonite ${"???"}
+           |${"???"}
+           |Java ${"???"}""".stripMargin, // +
+      // params.extraBannerOpt.fold("")("\n\n" + _),
+      help_links = None // Some(params.extraLinks.toList).filter(_.nonEmpty)
+    )
+
+  var params = LauncherParameters()
+
+  def execute(
+    code: String,
+    storeHistory: Boolean,
+    inputManager: Option[InputManager],
+    outputHandler: Option[OutputHandler]
+  ): ExecuteResult = {
+    val path      = Left(s"cell$lineCount0.sc")
+    val scopePath = ScopePath(Left("."), os.sub)
+    ExtractedDirectives.from(code.toCharArray, path) match {
+      case Left(ex) =>
+        LauncherInterpreter.error(LauncherInterpreter.Colors.default, Some(ex), "")
+      case Right(directives) =>
+        val directivesErrorOpt =
+          if (directives.directives.isEmpty)
+            None
+          else {
+            // FIXME There might be actual code alongside directives
+
+            val scopedDirectives = directives.directives.map { dir =>
+              ScopedDirective(dir, path, scopePath)
+            }
+            val res = scopedDirectives
+              .map { dir =>
+                LauncherInterpreter.handlersMap.get(dir.directive.key) match {
+                  case Some(h) =>
+                    h.handleValues(dir).map(_.global.map(_.launcherParameters))
+                  case None =>
+                    Left(dir.unusedDirectiveError)
+                }
+              }
+              .sequence
+              .left.map(CompositeDirectiveException(_))
+              .map(_.flatMap(_.toSeq).foldLeft(LauncherParameters())(_ + _))
+
+            res match {
+              case Left(ex) =>
+                val err = LauncherInterpreter.error(
+                  LauncherInterpreter.Colors.default,
+                  Some(ex),
+                  "Error while processing using directives"
+                )
+                Some(err)
+              case Right(paramsUpdate) =>
+                params = params + paramsUpdate
+                None
+            }
+          }
+
+        directivesErrorOpt.getOrElse {
+          if (ScalaParser.hasActualCode(code))
+            // handing over execution to the actual kernel
+            ExecuteResult.Close
+          else {
+            lineCount0 += 1
+            ExecuteResult.Success(DisplayData.empty)
+          }
+        }
+    }
+  }
+
+  private var lineCount0 = 0
+  def lineCount          = lineCount0
+  def currentLine(): Int =
+    lineCount0
+}
+
+object LauncherInterpreter {
+
+  private val handlers = Seq[DirectiveHandler[directives.HasLauncherParameters]](
+    directives.JavaOptions.handler,
+    directives.Jvm.handler,
+    directives.ScalaVersion.handler
+  )
+
+  private val handlersMap = handlers.flatMap(h => h.keys.map(_ -> h)).toMap
+
+  // FIXME Also in almond.Execute
+  private def highlightFrame(
+    f: StackTraceElement,
+    highlightError: fansi.Attrs,
+    source: fansi.Attrs
+  ) = {
+    val src =
+      if (f.isNativeMethod) source("Native Method")
+      else if (f.getFileName == null) source("Unknown Source")
+      else source(f.getFileName) ++ ":" ++ source(f.getLineNumber.toString)
+
+    val prefix :+ clsName = f.getClassName.split('.').toSeq
+    val prefixString      = prefix.map(_ + '.').mkString("")
+    val clsNameString     = clsName // .replace("$", error("$"))
+    val method =
+      fansi.Str(prefixString) ++ highlightError(clsNameString) ++ "." ++
+        highlightError(f.getMethodName)
+
+    fansi.Str(s"  ") ++ method ++ "(" ++ src ++ ")"
+  }
+
+  // FIXME Also in almond.Execute
+  def showException(
+    ex: Throwable,
+    error: fansi.Attrs,
+    highlightError: fansi.Attrs,
+    source: fansi.Attrs
+  ) = {
+
+    val cutoff = Set("$main", "evaluatorRunPrinter")
+    val traces = Ex.unapplySeq(ex).get.map(exception =>
+      error(exception.toString).render + System.lineSeparator() +
+        exception
+          .getStackTrace
+          .takeWhile(x => !cutoff(x.getMethodName))
+          .map(highlightFrame(_, highlightError, source))
+          .mkString(System.lineSeparator())
+    )
+    traces.mkString(System.lineSeparator())
+  }
+
+  // FIXME Also in almond.Execute
+  private def error(colors: Colors, exOpt: Option[Throwable], msg: String) =
+    ExecuteResult.Error(
+      msg + exOpt.fold("")(ex =>
+        (if (msg.isEmpty) "" else "\n") + showException(
+          ex,
+          colors.error,
+          fansi.Attr.Reset,
+          colors.literal
+        )
+      )
+    )
+
+  // from Model.scala in Ammonite
+  object Ex {
+    def unapplySeq(t: Throwable): Option[Seq[Throwable]] = {
+      def rec(t: Throwable): List[Throwable] =
+        t match {
+          case null => Nil
+          case t    => t :: rec(t.getCause)
+        }
+      Some(rec(t))
+    }
+  }
+  case class Colors(
+    prompt: fansi.Attrs,
+    ident: fansi.Attrs,
+    `type`: fansi.Attrs,
+    literal: fansi.Attrs,
+    prefix: fansi.Attrs,
+    comment: fansi.Attrs,
+    keyword: fansi.Attrs,
+    selected: fansi.Attrs,
+    error: fansi.Attrs,
+    warning: fansi.Attrs,
+    info: fansi.Attrs
+  )
+
+  object Colors {
+
+    def default = Colors(
+      fansi.Color.Magenta,
+      fansi.Color.Cyan,
+      fansi.Color.Green,
+      fansi.Color.Green,
+      fansi.Color.Yellow,
+      fansi.Color.Blue,
+      fansi.Color.Yellow,
+      fansi.Reversed.On,
+      fansi.Color.Red,
+      fansi.Color.Yellow,
+      fansi.Color.Blue
+    )
+    def blackWhite = Colors(
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty,
+      fansi.Attrs.Empty
+    )
+  }
+}

--- a/modules/scala/launcher/src/main/scala/almond/launcher/LauncherOptions.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/LauncherOptions.scala
@@ -1,0 +1,53 @@
+package almond.launcher
+
+import caseapp._
+
+import scala.collection.mutable
+
+// format: off
+final case class LauncherOptions(
+  log: Option[String] = None,
+  connectionFile: Option[String] = None,
+  variableInspector: Option[Boolean] = None,
+  toreeMagics: Option[Boolean] = None,
+  color: Option[Boolean] = None,
+  @HelpMessage("Send log to a file rather than stderr")
+  @ValueDescription("/path/to/log-file")
+    logTo: Option[String] = None,
+  scala: Option[String] = None,
+  @ExtraName("extraCp")
+  @ExtraName("extraClasspath")
+    extraClassPath: List[String] = Nil,
+  predef: List[String] = Nil,
+  extraStartupClassPath: List[String] = Nil,
+  sharedDependencies: List[String] = Nil,
+  compileOnly: Option[Boolean] = None
+) {
+  // format: on
+
+  def kernelOptions: Seq[String] = {
+    val b = new mutable.ListBuffer[String]
+    for (value <- log)
+      b ++= Seq("--log", value)
+    for (value <- variableInspector)
+      b ++= Seq(s"--variable-inspector=$value")
+    for (value <- toreeMagics)
+      b ++= Seq(s"--toree-magics=$value")
+    for (value <- color)
+      b ++= Seq(s"--color=$value")
+    for (value <- logTo)
+      b ++= Seq("--log-to", value)
+    for (value <- extraClassPath)
+      b ++= Seq("--extra-class-path", value)
+    for (value <- predef)
+      b ++= Seq("--predef", value)
+    for (value <- compileOnly)
+      b ++= Seq(s"--compile-only=$value")
+    b.result()
+  }
+}
+
+object LauncherOptions {
+  implicit lazy val parser: Parser[LauncherOptions] = Parser.derive
+  implicit lazy val help: Help[LauncherOptions]     = Help.derive
+}

--- a/modules/scala/launcher/src/main/scala/almond/launcher/LauncherParameters.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/LauncherParameters.scala
@@ -1,0 +1,14 @@
+package almond.launcher
+
+final case class LauncherParameters(
+  jvm: Option[String] = None,
+  javaOptions: Seq[String] = Nil,
+  scala: Option[String] = None
+) {
+  def +(other: LauncherParameters): LauncherParameters =
+    LauncherParameters(
+      jvm.orElse(other.jvm),
+      javaOptions ++ other.javaOptions,
+      scala.orElse(other.scala)
+    )
+}

--- a/modules/scala/launcher/src/main/scala/almond/launcher/Properties.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/Properties.scala
@@ -1,0 +1,28 @@
+package almond.launcher
+
+import java.io.ByteArrayInputStream
+import java.util.{Properties => JProperties}
+
+object Properties {
+
+  private lazy val path = os.resource / "almond" / "launcher" / "launcher.properties"
+  private lazy val props = {
+    val content = os.read.bytes(path)
+
+    val p = new JProperties
+    p.load(new ByteArrayInputStream(content))
+    p
+  }
+
+  private def prop(name: String) =
+    Option(props.getProperty(name)).getOrElse {
+      sys.error(s"$name property not found in $path")
+    }
+
+  lazy val version    = prop("version")
+  lazy val commitHash = prop("commit-hash")
+
+  lazy val kernelMainClass     = prop("kernel-main-class")
+  lazy val defaultScalaVersion = prop("default-scala-version")
+
+}

--- a/modules/scala/launcher/src/main/scala/almond/launcher/ScalaParser.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/ScalaParser.scala
@@ -1,0 +1,15 @@
+package almond.launcher
+
+import fastparse._
+
+import fastparse.ScalaWhitespace._
+import scalaparse.Scala._
+
+object ScalaParser {
+
+  def AllWS[X: P] = Start ~ WS ~ End
+
+  def hasActualCode(code: String): Boolean =
+    !parse(code, AllWS(_)).isSuccess
+
+}

--- a/modules/scala/launcher/src/main/scala/almond/launcher/directives/HasLauncherParameters.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/directives/HasLauncherParameters.scala
@@ -1,0 +1,7 @@
+package almond.launcher.directives
+
+import almond.launcher.LauncherParameters
+
+trait HasLauncherParameters {
+  def launcherParameters: LauncherParameters
+}

--- a/modules/scala/launcher/src/main/scala/almond/launcher/directives/JavaOptions.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/directives/JavaOptions.scala
@@ -1,0 +1,25 @@
+package almond.launcher.directives
+
+import almond.launcher.LauncherParameters
+
+import scala.cli.directivehandler._
+
+@DirectiveGroupName("Java options")
+@DirectiveExamples("//> using javaOpt -Xmx2g, -Dsomething=a")
+@DirectiveUsage(
+  "//> using javaOpt _options_",
+  "`//> using javaOpt `_options_"
+)
+@DirectiveDescription("Add Java options which will be passed when running an application.")
+final case class JavaOptions(
+  @DirectiveName("javaOpt")
+  javaOptions: List[Positioned[String]] = Nil
+) extends HasLauncherParameters {
+  def launcherParameters = LauncherParameters(
+    javaOptions = javaOptions.map(_.value)
+  )
+}
+
+object JavaOptions {
+  val handler: DirectiveHandler[JavaOptions] = DirectiveHandler.derive
+}

--- a/modules/scala/launcher/src/main/scala/almond/launcher/directives/Jvm.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/directives/Jvm.scala
@@ -1,0 +1,26 @@
+package almond.launcher.directives
+
+import almond.launcher.LauncherParameters
+
+import scala.cli.directivehandler._
+
+@DirectiveGroupName("JVM version")
+@DirectiveExamples("//> using jvm 11")
+@DirectiveExamples("//> using jvm adopt:11")
+@DirectiveExamples("//> using jvm graalvm:21")
+@DirectiveUsage(
+  "//> using jvm _value_",
+  "`//> using jvm` _value_"
+)
+@DirectiveDescription("Use a specific JVM, such as `14`, `adopt:11`, or `graalvm:21`, or `system`")
+final case class Jvm(
+  jvm: Option[Positioned[String]] = None
+) extends HasLauncherParameters {
+  def launcherParameters = LauncherParameters(
+    jvm = jvm.map(_.value).filter(_.trim.nonEmpty)
+  )
+}
+
+object Jvm {
+  val handler: DirectiveHandler[Jvm] = DirectiveHandler.derive
+}

--- a/modules/scala/launcher/src/main/scala/almond/launcher/directives/ScalaVersion.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/directives/ScalaVersion.scala
@@ -1,0 +1,26 @@
+package almond.launcher.directives
+
+import almond.launcher.LauncherParameters
+
+import scala.cli.directivehandler._
+
+@DirectiveGroupName("Scala version")
+@DirectiveExamples("//> using scala 3.0.2")
+@DirectiveExamples("//> using scala 2.13")
+@DirectiveExamples("//> using scala 2")
+@DirectiveUsage(
+  "//> using scala _version_",
+  "`//> using scala `_version_"
+)
+@DirectiveDescription("Set the Scala version")
+final case class ScalaVersion(
+  scala: Option[String] = None
+) extends HasLauncherParameters {
+  def launcherParameters = LauncherParameters(
+    scala = scala.filter(_.trim.nonEmpty)
+  )
+}
+
+object ScalaVersion {
+  val handler: DirectiveHandler[ScalaVersion] = DirectiveHandler.derive
+}

--- a/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
@@ -39,7 +39,8 @@ final class Execute(
   commHandlerOpt: => Option[CommHandler],
   silent: Ref[Boolean],
   useThreadInterrupt: Boolean,
-  initialCellCount: Int
+  initialCellCount: Int,
+  enableExitHack: Boolean
 ) {
 
   private val log = logCtx(getClass)
@@ -342,6 +343,11 @@ final class Execute(
     storeHistory: Boolean,
     executeHooks: Seq[JupyterApi.ExecuteHook]
   ): ExecuteResult = {
+
+    if (enableExitHack && code.endsWith("// ALMOND FORCE EXIT")) {
+      log.debug("Exit hack enabled and code ends with force-exit comment, exiting")
+      sys.exit(0)
+    }
 
     if (storeHistory) {
       storage.fullHistory() = storage.fullHistory() :+ code

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -72,7 +72,8 @@ final class ScalaInterpreter(
     commHandlerOpt,
     silent0,
     params.useThreadInterrupt,
-    params.initialCellCount
+    params.initialCellCount,
+    enableExitHack = params.compileOnly
   )
 
   val sessApi = new SessionApiImpl(frames0)

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
@@ -323,16 +323,22 @@ object ScalaKernelTests extends TestSuite {
         )
 
         val expectedPublishMessageTypes = Seq(
-          "execute_input",
-          "display_data",
-          "execute_input",
-          "update_display_data",
-          "execute_input",
-          "update_display_data"
+          Set(
+            "execute_input",
+            "display_data"
+          ),
+          Set(
+            "execute_input",
+            "update_display_data"
+          ),
+          Set(
+            "execute_input",
+            "update_display_data"
+          )
         )
 
         assert(requestsMessageTypes == expectedRequestsMessageTypes)
-        assert(publishMessageTypes == expectedPublishMessageTypes)
+        TestUtil.comparePublishMessageTypes(expectedPublishMessageTypes, publishMessageTypes)
 
         val displayData = streams.displayData.map {
           case (d, b) =>

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
@@ -12,7 +12,7 @@ import almond.kernel.{Kernel, KernelThreads}
 import almond.protocol.{Execute => ProtocolExecute, _}
 import almond.testkit.{ClientStreams, Dsl}
 import almond.testkit.TestLogging.logCtx
-import almond.TestUtil.{IOOps, KernelOps, SessionId, execute => executeMessage, isScala212}
+import almond.TestUtil.{IOOps, KernelOps, execute => executeMessage, isScala212}
 import almond.util.SequentialExecutionContext
 import almond.util.ThreadUtil.{attemptShutdownExecutionContext, singleThreadedExecutionContext}
 import ammonite.util.Colors
@@ -85,7 +85,7 @@ object ScalaKernelTests extends TestSuite {
         (_, m) =>
           IO.pure(m.header.msg_type == "execute_reply" && m.content.toString().contains("exit"))
 
-      implicit val sessionId: SessionId = SessionId()
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
 
       // Initial messages from client
 
@@ -134,7 +134,7 @@ object ScalaKernelTests extends TestSuite {
       val kernel = Kernel.create(interpreter, interpreterEc, threads, logCtx)
         .unsafeRunTimedOrThrow()
 
-      implicit val sessionId: SessionId = SessionId()
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
 
       val lastMsgId = UUID.randomUUID().toString
 
@@ -234,7 +234,7 @@ object ScalaKernelTests extends TestSuite {
       val kernel = Kernel.create(interpreter, interpreterEc, threads, logCtx)
         .unsafeRunTimedOrThrow()
 
-      implicit val sessionId: SessionId = SessionId()
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
 
       val tpeName =
         if (scalaVersion.startsWith("2.")) "java.net.URL"
@@ -291,7 +291,7 @@ object ScalaKernelTests extends TestSuite {
         val kernel = Kernel.create(interpreter, interpreterEc, threads, logCtx)
           .unsafeRunTimedOrThrow()
 
-        implicit val sessionId: SessionId = SessionId()
+        implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
 
         val lastMsgId = UUID.randomUUID().toString
         val stopWhen: (Channel, Message[RawJson]) => IO[Boolean] =
@@ -382,7 +382,7 @@ object ScalaKernelTests extends TestSuite {
       val kernel = Kernel.create(interpreter, interpreterEc, threads, logCtx)
         .unsafeRunTimedOrThrow()
 
-      implicit val sessionId: SessionId = SessionId()
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
 
       val lastMsgId = UUID.randomUUID().toString
       val stopWhen: (Channel, Message[RawJson]) => IO[Boolean] =
@@ -510,7 +510,7 @@ object ScalaKernelTests extends TestSuite {
       val kernel = Kernel.create(interpreter, interpreterEc, threads, logCtx)
         .unsafeRunTimedOrThrow()
 
-      implicit val sessionId: SessionId = SessionId()
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
 
       kernel.execute(
         "val before = foos()",
@@ -563,7 +563,7 @@ object ScalaKernelTests extends TestSuite {
       val kernel = Kernel.create(interpreter, interpreterEc, threads, logCtx)
         .unsafeRunTimedOrThrow()
 
-      implicit val sessionId: SessionId = SessionId()
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
 
       val sbv =
         if (scalaVersion.startsWith("2.")) scalaVersion.split('.').take(2).mkString(".")
@@ -641,7 +641,7 @@ object ScalaKernelTests extends TestSuite {
       val kernel = Kernel.create(interpreter, interpreterEc, threads, logCtx)
         .unsafeRunTimedOrThrow()
 
-      implicit val sessionId: SessionId = SessionId()
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
 
       kernel.execute(
         """%%html
@@ -672,7 +672,7 @@ object ScalaKernelTests extends TestSuite {
       val kernel = Kernel.create(interpreter, interpreterEc, threads, logCtx)
         .unsafeRunTimedOrThrow()
 
-      implicit val sessionId: SessionId = SessionId()
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
 
       val nl = System.lineSeparator()
 

--- a/modules/scala/scala-interpreter/src/test/scala/almond/TestUtil.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/TestUtil.scala
@@ -77,18 +77,21 @@ object TestUtil {
       apply(options: _*)
     }
 
-    def withSession[T](options: String*)(f: Dsl.Session => T): T = {
+    def withSession[T](options: String*)(f: Dsl.Session => T)(implicit
+      sessionId: Dsl.SessionId
+    ): T = {
       val sess = apply(options: _*)
       f(sess)
     }
-    def withExtraClassPathSession[T](extraClassPath: String*)(options: String*)(f: Dsl.Session => T)
-      : T = {
+    def withExtraClassPathSession[T](extraClassPath: String*)(options: String*)(
+      f: Dsl.Session => T
+    )(implicit sessionId: Dsl.SessionId): T = {
       val sess = withExtraClassPath(extraClassPath: _*)(options: _*)
       f(sess)
     }
     def withLauncherOptionsSession[T](launcherOptions: String*)(options: String*)(
       f: Dsl.Session => T
-    ): T = {
+    )(implicit sessionId: Dsl.SessionId): T = {
       val sess = withLauncherOptions(launcherOptions: _*)(options: _*)
       f(sess)
     }

--- a/modules/scala/scala-interpreter/src/test/scala/almond/TestUtil.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/TestUtil.scala
@@ -375,4 +375,13 @@ object TestUtil {
     }
   }
 
+  def comparePublishMessageTypes(expected: Seq[Set[String]], got: Seq[String]): Boolean =
+    expected.map(_.size).sum == got.length && {
+      val it = got.iterator
+      expected.forall { expectedGroup =>
+        val got0 = it.take(expectedGroup.size).toSet
+        expectedGroup == got0
+      }
+    }
+
 }

--- a/modules/scala/scala-interpreter/src/test/scala/almond/TestUtil.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/TestUtil.scala
@@ -57,8 +57,6 @@ object TestUtil {
       }
   }
 
-  final case class SessionId(sessionId: String = UUID.randomUUID().toString)
-
   final class KernelSession(kernel: Kernel) extends Dsl.Session {
     def run(streams: ClientStreams): Unit =
       kernel.run(streams.source, streams.sink, Nil)
@@ -151,7 +149,7 @@ object TestUtil {
       stderr: String = null,
       waitForUpdateDisplay: Boolean = false,
       handler: MessageHandler = MessageHandler.discard { case _ => }
-    )(implicit sessionId: SessionId): Unit = {
+    )(implicit sessionId: Dsl.SessionId): Unit = {
 
       val expectError0   = expectError || Option(errors).nonEmpty
       val ignoreStreams0 = ignoreStreams || Option(stdout).nonEmpty || Option(stderr).nonEmpty
@@ -293,7 +291,7 @@ object TestUtil {
     code: String,
     msgId: String = UUID.randomUUID().toString,
     stopOnError: Boolean = true
-  )(implicit sessionId: SessionId) =
+  )(implicit sessionId: Dsl.SessionId) =
     Message(
       Header(
         msgId,
@@ -315,8 +313,8 @@ object TestUtil {
 
       val (input, replies) = inputs.unzip
 
-      implicit val sessionId: SessionId = SessionId()
-      val lastMsgId                     = UUID.randomUUID().toString
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
+      val lastMsgId                         = UUID.randomUUID().toString
 
       val stopWhen: (Channel, Message[RawJson]) => IO[Boolean] =
         (_, m) =>

--- a/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
+++ b/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
@@ -16,7 +16,7 @@ import scala.util.Properties
 object Tests {
 
   private val sp = " "
-  private val ls = System.lineSeparator()
+  val ls         = System.lineSeparator()
 
   private def maybePostImportNewLine(isScala2: Boolean) =
     if (isScala2) "" else System.lineSeparator()
@@ -473,7 +473,12 @@ object Tests {
     val predefPath = tmpDir / "predef.sc"
     os.write(predefPath, predef)
 
-    runner.withLauncherOptionsSession("--shared", "sh.almond::toree-hooks")(
+    val launcherOptions =
+      if (runner.differedStartUp)
+        Seq("--shared-dependencies", "sh.almond::toree-hooks:_")
+      else
+        Seq("--shared", "sh.almond::toree-hooks")
+    runner.withLauncherOptionsSession(launcherOptions: _*)(
       "--toree-magics",
       "--predef",
       predefPath.toString
@@ -634,6 +639,10 @@ object Tests {
 
     runner.withSession("--extra-class-path", extraJars.mkString(File.pathSeparator)) {
       implicit session =>
+        if (runner.differedStartUp)
+          // In two step start up, we need the actual kernel to have started to get inspection results
+          execute("val n = 2", "n: Int = 2")
+
         val code   = "os.read"
         val result = inspect(code, code.length - 3, detailed = true)
         val expected = Seq(

--- a/modules/shared/test-kit/src/main/scala/almond/testkit/Dsl.scala
+++ b/modules/shared/test-kit/src/main/scala/almond/testkit/Dsl.scala
@@ -23,6 +23,8 @@ object Dsl {
     def withExtraClassPathSession[T](extraClassPath: String*)(options: String*)(f: Session => T): T
     def withLauncherOptionsSession[T](launcherOptions: String*)(options: String*)(f: Session => T)
       : T
+
+    def differedStartUp: Boolean = false
   }
 
   trait Session {

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -4,6 +4,7 @@ import mill.scalalib._
 object Versions {
   def ammonite      = "3.0.0-M0-28-239e82a8"
   def caseApp       = "2.1.0-M24"
+  def coursier      = "2.1.4"
   def jsoniterScala = "2.13.5"
   def scalafmt      = "2.7.5"
 }
@@ -45,9 +46,12 @@ object Deps {
   def caseApp            = ivy"com.github.alexarchambault::case-app:${Versions.caseApp}"
   def classPathUtil      = ivy"io.get-coursier::class-path-util:0.1.4"
   def collectionCompat   = ivy"org.scala-lang.modules::scala-collection-compat:2.10.0"
-  def coursier           = ivy"io.get-coursier::coursier:2.1.4"
+  def coursier           = ivy"io.get-coursier::coursier:${Versions.coursier}"
   def coursierApi        = ivy"io.get-coursier:interface:1.0.16"
+  def coursierLauncher   = ivy"io.get-coursier:coursier-launcher_2.13:${Versions.coursier}"
+  def directiveHandler   = ivy"io.github.alexarchambault.scala-cli::directive-handler:0.1.0"
   def expecty            = ivy"com.eed3si9n.expecty::expecty:0.16.0"
+  def fansi              = ivy"com.lihaoyi::fansi:0.4.0"
   def fs2(sv: String) =
     if (sv.startsWith("2.")) ivy"co.fs2::fs2-core:3.7.0" else ivy"co.fs2:fs2-core_2.13:3.6.1"
   def jansi  = ivy"org.fusesource.jansi:jansi:2.4.0"
@@ -63,6 +67,7 @@ object Deps {
   def osLib                    = ivy"com.lihaoyi::os-lib:0.9.1"
   def pprint                   = ivy"com.lihaoyi::pprint:0.8.1"
   def scalafmtDynamic          = ivy"org.scalameta::scalafmt-dynamic:${Versions.scalafmt}"
+  def scalaparse               = ivy"com.lihaoyi::scalaparse:3.0.1"
   def scalapy                  = ivy"me.shadaj::scalapy-core:0.5.2"
   def scalaReflect(sv: String) = ivy"org.scala-lang:scala-reflect:$sv"
   def scalaRx                  = ivy"com.lihaoyi::scalarx:0.4.3"

--- a/project/jupyterserver.sc
+++ b/project/jupyterserver.sc
@@ -1,17 +1,18 @@
 import java.nio.file._
 
-def kernelId = "scala-debug"
+def kernelId        = "scala-debug"
+def specialKernelId = "scala-special-debug"
 
-def writeKernelJson(launcher: Path, jupyterDir: Path): Unit = {
+def writeKernelJson(launcher: Path, jupyterDir: Path, kernelId: String, name: String): Unit = {
   val launcherPath = launcher.toAbsolutePath.toString
   val dir          = jupyterDir.resolve(s"kernels/$kernelId")
   Files.createDirectories(dir)
   val kernelJson = s"""{
     "language": "scala",
-    "display_name": "Scala (sources)",
+    "display_name": "$name",
     "argv": [
       "$launcherPath",
-      "--log", "info",
+      "--log", "debug",
       "--connection-file", "{connection_file}",
       "--variable-inspector",
       "--toree-magics"
@@ -21,9 +22,15 @@ def writeKernelJson(launcher: Path, jupyterDir: Path): Unit = {
   System.err.println(s"JUPYTER_PATH=$jupyterDir")
 }
 
-def jupyterServer(launcher: Path, jupyterDir: Path, args: Seq[String]): Unit = {
+def jupyterServer(
+  launcher: Path,
+  specialLauncher: Path,
+  jupyterDir: Path,
+  args: Seq[String]
+): Unit = {
 
-  writeKernelJson(launcher, jupyterDir)
+  writeKernelJson(launcher, jupyterDir, kernelId, "Scala (sources)")
+  writeKernelJson(specialLauncher, jupyterDir, specialKernelId, "Scala (special, sources)")
 
   os.makeDir.all(os.pwd / "notebooks")
   val jupyterCommand = Seq("jupyter", "lab", "--notebook-dir", "notebooks")
@@ -43,9 +50,15 @@ def jupyterServer(launcher: Path, jupyterDir: Path, args: Seq[String]): Unit = {
     System.err.println(s"Jupyter command exited with code $retCode")
 }
 
-def jupyterConsole(launcher: Path, jupyterDir: Path, args: Seq[String]): Unit = {
+def jupyterConsole(
+  launcher: Path,
+  specialLauncher: Path,
+  jupyterDir: Path,
+  args: Seq[String]
+): Unit = {
 
-  writeKernelJson(launcher, jupyterDir)
+  writeKernelJson(launcher, jupyterDir, kernelId, "Scala (sources)")
+  writeKernelJson(specialLauncher, jupyterDir, specialKernelId, "Scala (special, sources)")
 
   val jupyterCommand = Seq("jupyter", "console", s"--kernel=$kernelId")
   val b              = new ProcessBuilder(jupyterCommand ++ args: _*).inheritIO()

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -190,6 +190,15 @@ trait AlmondScalacOptions extends ScalaModule {
   }
 }
 
+trait AlmondSimpleModule
+    extends SbtModule
+    with AlmondRepositories
+    with AlmondPublishModule
+    with TransitiveSources
+    with AlmondArtifactName
+    with PublishLocalNoFluff
+    with AlmondScalacOptions
+
 trait AlmondModule
     extends CrossSbtModule
     with AlmondRepositories
@@ -322,7 +331,7 @@ trait AlmondTestModule
   }
 }
 
-trait BootstrapLauncher extends CrossSbtModule {
+trait BootstrapLauncher extends SbtModule {
 
   def launcherClassPath       = T(runClasspath())
   def launcherSharedClassPath = T(Seq.empty[PathRef])


### PR DESCRIPTION
This basically adds a new launcher, that behaves as a Jupyter kernel, but only handles using directives (same format as Scala CLI). This launcher handles directives like
```scala
//> using jvm "17"
//> using javaOpt "-Xmx4g"
//> using scala "2.13.10"
```

As soon as it runs into actual code, it fetches and spawns the actual Almond kernel for the right Scala version, optionally fetching a JVM (using coursier's JVM handling capabilities) and passing some Java options if users asked to.