### PR TITLE
Set proper fields in ExecuteReply.Error and Execute.error

### DIFF
--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaInterpreterTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaInterpreterTests.scala
@@ -181,9 +181,11 @@ object ScalaInterpreterTests extends TestSuite {
       }
 
       "exception" - {
-        val code = """sys.error("foo")"""
+        val code = """sys.error("foo\nbar")"""
         val res  = interpreter.execute(code)
-        assert(res.asError.exists(_.message.contains("java.lang.RuntimeException: foo")))
+        assert(res.asError.exists(_.name.contains("java.lang.RuntimeException")))
+        assert(res.asError.exists(_.message.contains("foo\nbar")))
+        assert(res.asError.exists(_.stackTrace.exists(_.contains("cmd"))))
       }
     }
 

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
@@ -151,6 +151,14 @@ object ScalaKernelTests extends TestSuite {
 
       assert(messageTypes == expectedMessageTypes)
 
+      val executeErrors = streams.executeErrors
+      assert(executeErrors.size == 1)
+      assert(executeErrors.head.ename == "java.lang.RuntimeException")
+      assert(executeErrors.head.evalue == "foo")
+      val traceback = executeErrors.head.traceback.asInstanceOf[Seq[String]]
+      assert(traceback.exists(_.contains("java.lang.RuntimeException: foo")))
+      assert(traceback.exists(_.contains("cmd0")))
+
       val replies = streams.executeReplies
 
       // first code is in error, subsequent ones are cancelled because of the stop-on-error, so no results here

--- a/modules/shared/interpreter/src/main/scala/almond/interpreter/messagehandlers/InterpreterMessageHandlers.scala
+++ b/modules/shared/interpreter/src/main/scala/almond/interpreter/messagehandlers/InterpreterMessageHandlers.scala
@@ -79,7 +79,7 @@ final case class InterpreterMessageHandlers(
                 )
               else
                 IO.unit
-            val error = Execute.Error("", "", List(e.message))
+            val error = Execute.Error(e.name, e.message, e.stackTrace)
             extra *>
               message
                 .publish(Execute.errorType, error)
@@ -93,13 +93,10 @@ final case class InterpreterMessageHandlers(
           case v: ExecuteResult.Success =>
             Execute.Reply.Success(countAfter, v.data.jsonData)
           case ex: ExecuteResult.Error =>
-            val traceBack = Seq(ex.name, ex.message).filter(_.nonEmpty).mkString(
-              ": "
-            ) :: ex.stackTrace.map("    " + _)
             Execute.Reply.Error(
               ex.name,
               ex.message,
-              traceBack /* or just stackTrace? */,
+              ex.stackTrace,
               countAfter
             )
           case ExecuteResult.Abort =>

--- a/modules/shared/kernel/src/test/scala/almond/kernel/ClientStreams.scala
+++ b/modules/shared/kernel/src/test/scala/almond/kernel/ClientStreams.scala
@@ -185,6 +185,23 @@ final case class ClientStreams(
       .flatten
       .toList
 
+  def executeErrors: Seq[Execute.Error] =
+    generatedMessages
+      .iterator
+      .collect {
+        case Left((Channel.Publish, m)) if m.header.msg_type == Execute.errorType.messageType =>
+          println(m)
+          m.decodeAs[Execute.Error] match {
+            case Left(_) => Nil
+            case Right(m) =>
+              m.content match {
+                case e: Execute.Error => Seq(e)
+                case _ => Nil
+              }
+          }
+      }
+      .flatten
+      .toList
 }
 
 object ClientStreams {


### PR DESCRIPTION
## What changed?
Current code constructs Execute.error (which is then translated to ExecuteReply.error) by setting `ename="", stackTrace=Nil, evalue=<the whole exception as a string>`. While this is rendered correctly in Jupyter(Lab), it feels like a semantical violation of Jupyter messaging protocol. This PR aims to fix that.

Please let me know if `ename` and `stackTrace` fields were left blank intentionally! 

## How is it tested?
- additional checks in `ScalaInterpreterTests` verifying `ename` and `stackTrace` fields of `ExecuteReply.Error` message
- additional checks in `ScalaKernelTests` verifying `ename` and `stackTrace` fields of `Execute.Error` message
- manually verified that JupyterLab displays errors identically with and without this change and that my changes could be observed in a browser WS channel. 

Before change:
![image](https://github.com/almond-sh/almond/assets/117097225/3b0aa253-27c4-4bab-be13-58f662e7aa61)
![image](https://github.com/almond-sh/almond/assets/117097225/d13f1937-7aff-4da1-9a06-ffad6ee60a7c)
![image](https://github.com/almond-sh/almond/assets/117097225/8c16b63f-e54d-483d-a45a-37bb657888df)

After change:
![image](https://github.com/almond-sh/almond/assets/117097225/3169dbfc-6baf-4b5c-bd32-bc32a534d98f)
![image](https://github.com/almond-sh/almond/assets/117097225/f52ea2d7-adbb-4a97-9544-4fca311a7007)
![image](https://github.com/almond-sh/almond/assets/117097225/13b403ad-98fc-4c7d-b302-2052aee6a186)

