### PR TITLE
Set proper fields in ExecuteReply.Error and Execute.error

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
@@ -414,15 +414,13 @@ final class Execute(
                 val cutoff = Set("$main", "evaluatorRunPrinter")
 
                 ExecuteResult.Error(
-                  (
-                    "Interrupted!" +: st
-                      .takeWhile(x => !cutoff(x.getMethodName))
-                      .map(ExecuteResult.Error.highlightFrame(
-                        _,
-                        fansi.Attr.Reset,
-                        colors0().literal()
-                      ))
-                  ).mkString(System.lineSeparator())
+                  "Interrupted!",
+                  "",
+                  List("Interrupted!") ++ st
+                    .takeWhile(x => !cutoff(x.getMethodName))
+                    .map(ExecuteResult.Error.highlightFrame(_, fansi.Attr.Reset, colors0().literal()))
+                    .map(_.render)
+                    .toList
                 )
             }
 

--- a/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
@@ -418,7 +418,11 @@ final class Execute(
                   "",
                   List("Interrupted!") ++ st
                     .takeWhile(x => !cutoff(x.getMethodName))
-                    .map(ExecuteResult.Error.highlightFrame(_, fansi.Attr.Reset, colors0().literal()))
+                    .map(ExecuteResult.Error.highlightFrame(
+                      _,
+                      fansi.Attr.Reset,
+                      colors0().literal()
+                    ))
                     .map(_.render)
                     .toList
                 )

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaInterpreterTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaInterpreterTests.scala
@@ -181,9 +181,11 @@ object ScalaInterpreterTests extends TestSuite {
       }
 
       test("exception") {
-        val code = """sys.error("foo")"""
+        val code = """sys.error("foo\nbar")"""
         val res  = interpreter.execute(code)
-        assert(res.asError.exists(_.message.contains("java.lang.RuntimeException: foo")))
+        assert(res.asError.exists(_.name.contains("java.lang.RuntimeException")))
+        assert(res.asError.exists(_.message.contains("foo\nbar")))
+        assert(res.asError.exists(_.stackTrace.exists(_.contains("ammonite."))))
       }
     }
 

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
@@ -179,7 +179,11 @@ object ScalaKernelTests extends TestSuite {
       val executeResultErrors = streams.executeResultErrors
       println(executeResultErrors)
       assert(executeResultErrors.size == 1)
-      checkError(executeResultErrors.head.ename, executeResultErrors.head.evalue, executeResultErrors.head.traceback)
+      checkError(
+        executeResultErrors.head.ename,
+        executeResultErrors.head.evalue,
+        executeResultErrors.head.traceback
+      )
 
       println(streams.executeErrors)
       val executeErrors = streams.executeErrors

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
@@ -169,6 +169,22 @@ object ScalaKernelTests extends TestSuite {
 
       assert(messageTypes == expectedMessageTypes)
 
+      def checkError(ename: String, evalue: String, traceback: List[String]) = {
+        assert(ename == "java.lang.RuntimeException")
+        assert(evalue == "foo")
+        assert(traceback.exists(_.contains("java.lang.RuntimeException: foo")))
+        assert(traceback.exists(_.contains("ammonite.")))
+      }
+
+      val executeResultErrors = streams.executeResultErrors
+      println(executeResultErrors)
+      assert(executeResultErrors.size == 1)
+      checkError(executeResultErrors.head.ename, executeResultErrors.head.evalue, executeResultErrors.head.traceback)
+
+      println(streams.executeErrors)
+      val executeErrors = streams.executeErrors
+      checkError(executeErrors(1)._1, executeErrors(1)._2, executeErrors(1)._3)
+
       val replies = streams.executeReplies
 
       // first code is in error, subsequent ones are cancelled because of the stop-on-error, so no results here

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
@@ -177,7 +177,6 @@ object ScalaKernelTests extends TestSuite {
       }
 
       val executeResultErrors = streams.executeResultErrors
-      println(executeResultErrors)
       assert(executeResultErrors.size == 1)
       checkError(
         executeResultErrors.head.ename,
@@ -185,7 +184,6 @@ object ScalaKernelTests extends TestSuite {
         executeResultErrors.head.traceback
       )
 
-      println(streams.executeErrors)
       val executeErrors = streams.executeErrors
       checkError(executeErrors(1)._1, executeErrors(1)._2, executeErrors(1)._3)
 

--- a/modules/shared/interpreter/src/main/scala/almond/interpreter/ExecuteResult.scala
+++ b/modules/shared/interpreter/src/main/scala/almond/interpreter/ExecuteResult.scala
@@ -99,9 +99,8 @@ object ExecuteResult {
       error: fansi.Attrs,
       highlightError: fansi.Attrs,
       source: fansi.Attrs
-    ) = {
+    ) =
       exceptionToStackTraceLines(ex, error, highlightError, source).mkString(System.lineSeparator())
-    }
 
     def error(
       errorColor: fansi.Attrs,
@@ -112,12 +111,14 @@ object ExecuteResult {
       ExecuteResult.Error(
         exOpt.fold("")(_.getClass.getName),
         msg + exOpt.fold("")(_.getMessage),
-        exOpt.fold(List.empty[String])(ex => exceptionToStackTraceLines(
-          ex,
-          errorColor,
-          fansi.Attr.Reset,
-          literalColor
-        ).toList)
+        exOpt.fold(List.empty[String])(ex =>
+          exceptionToStackTraceLines(
+            ex,
+            errorColor,
+            fansi.Attr.Reset,
+            literalColor
+          ).toList
+        )
       )
   }
 

--- a/modules/shared/interpreter/src/main/scala/almond/interpreter/messagehandlers/InterpreterMessageHandlers.scala
+++ b/modules/shared/interpreter/src/main/scala/almond/interpreter/messagehandlers/InterpreterMessageHandlers.scala
@@ -87,7 +87,7 @@ final case class InterpreterMessageHandlers(
                     runAfterQueued(interpreter.cancelledSignal.set(false))
                 else
                   IO.unit
-              val error = Execute.Error("", "", List(e.message))
+              val error = Execute.Error(e.name, e.message, e.stackTrace)
               extra *>
                 message
                   .publish(Execute.errorType, error)

--- a/modules/shared/test-kit/src/main/scala/almond/testkit/ClientStreams.scala
+++ b/modules/shared/test-kit/src/main/scala/almond/testkit/ClientStreams.scala
@@ -236,7 +236,6 @@ final case class ClientStreams(
       .iterator
       .collect {
         case Left((Channel.Publish, m)) if m.header.msg_type == Execute.errorType.messageType =>
-          println(m)
           m.decodeAs[Execute.Error] match {
             case Left(_) => Nil
             case Right(m) =>

--- a/modules/shared/test-kit/src/main/scala/almond/testkit/ClientStreams.scala
+++ b/modules/shared/test-kit/src/main/scala/almond/testkit/ClientStreams.scala
@@ -242,7 +242,7 @@ final case class ClientStreams(
             case Right(m) =>
               m.content match {
                 case e: Execute.Error => Seq(e)
-                case _ => Nil
+                case _                => Nil
               }
           }
       }

--- a/modules/shared/test-kit/src/main/scala/almond/testkit/ClientStreams.scala
+++ b/modules/shared/test-kit/src/main/scala/almond/testkit/ClientStreams.scala
@@ -231,6 +231,24 @@ final case class ClientStreams(
       .flatten
       .toList
 
+  def executeResultErrors: Seq[Execute.Error] =
+    generatedMessages
+      .iterator
+      .collect {
+        case Left((Channel.Publish, m)) if m.header.msg_type == Execute.errorType.messageType =>
+          println(m)
+          m.decodeAs[Execute.Error] match {
+            case Left(_) => Nil
+            case Right(m) =>
+              m.content match {
+                case e: Execute.Error => Seq(e)
+                case _ => Nil
+              }
+          }
+      }
+      .flatten
+      .toList
+
   def inspectRepliesHtml: Seq[String] =
     generatedMessages
       .iterator


### PR DESCRIPTION
## What changed?
Current code constructs Execute.error (which is then translated to ExecuteReply.error) by setting `ename="", stackTrace=Nil, evalue=<the whole exception as a string>`. While this is rendered correctly in Jupyter(Lab), it feels like a semantical violation of Jupyter messaging protocol. This PR aims to fix that.

Please let me know if `ename` and `stackTrace` fields were left blank intentionally! 

## How is it tested?
- additional checks in `ScalaInterpreterTests` verifying `ename` and `stackTrace` fields of `ExecuteReply.Error` message
- additional checks in `ScalaKernelTests` verifying `ename` and `stackTrace` fields of `Execute.Error` message
- manually verified that JupyterLab displays errors identically with and without this change and that my changes could be observed in a browser WS channel. 

Before change:
![image](https://github.com/almond-sh/almond/assets/117097225/3b0aa253-27c4-4bab-be13-58f662e7aa61)
![image](https://github.com/almond-sh/almond/assets/117097225/d13f1937-7aff-4da1-9a06-ffad6ee60a7c)
![image](https://github.com/almond-sh/almond/assets/117097225/8c16b63f-e54d-483d-a45a-37bb657888df)

After change:
![image](https://github.com/almond-sh/almond/assets/117097225/3169dbfc-6baf-4b5c-bd32-bc32a534d98f)
![image](https://github.com/almond-sh/almond/assets/117097225/f52ea2d7-adbb-4a97-9544-4fca311a7007)
![image](https://github.com/almond-sh/almond/assets/117097225/13b403ad-98fc-4c7d-b302-2052aee6a186)

