### PR TITLE
Increase zeromq linger period

### DIFF
--- a/modules/shared/kernel/src/main/scala/almond/kernel/Kernel.scala
+++ b/modules/shared/kernel/src/main/scala/almond/kernel/Kernel.scala
@@ -211,7 +211,7 @@ final case class Kernel(
       c <- connection.channels(
         bind = true,
         zeromqThreads,
-        lingerPeriod = Some(10.seconds),
+        lingerPeriod = Some(5.minutes),
         logCtx = logCtx,
         identityOpt = Some(kernelId)
       )


### PR DESCRIPTION
Seems the handover from the first launcher to the main one sometimes loses messages when starting the kernel takes longer than this duration…