### PR TITLE
Add "quiet" interpreter param which controls mirroring stdout/stderr to console

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
@@ -41,6 +41,7 @@ import scala.util.{Failure, Success, Try}
   */
 final class Execute(
   trapOutput: Boolean,
+  quiet: Boolean,
   storage: Storage,
   logCtx: LoggerContext,
   updateBackgroundVariablesEcOpt: Option[ExecutionContext],
@@ -111,7 +112,7 @@ final class Execute(
     if (trapOutput)
       Capture.nop()
     else
-      Capture.create()
+      Capture.create(mirrorToConsole = !quiet)
 
   private val updatableResultsOpt0 =
     updateBackgroundVariablesEcOpt.map { ec =>

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -68,6 +68,7 @@ final class ScalaInterpreter(
 
   private val execute0 = new Execute(
     params.trapOutput,
+    params.quiet,
     storage,
     logCtx,
     params.updateBackgroundVariablesEcOpt,

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreterParams.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreterParams.scala
@@ -31,6 +31,7 @@ final case class ScalaInterpreterParams(
   metabrowsePort: Int = -1,
   lazyInit: Boolean = false,
   trapOutput: Boolean = false,
+  quiet: Boolean = true,
   disableCache: Boolean = false,
   autoUpdateLazyVals: Boolean = true,
   autoUpdateVars: Boolean = true,

--- a/modules/scala/scala-interpreter/src/main/scala/almond/internals/Capture.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/internals/Capture.scala
@@ -10,8 +10,8 @@ trait Capture {
 }
 
 object Capture {
-  def create(): Capture =
-    new CaptureImpl
+  def create(mirrorToConsole: Boolean): Capture =
+    new CaptureImpl(mirrorToConsole = mirrorToConsole)
   def nop(): Capture =
     new NopCapture
 }

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
@@ -1,7 +1,10 @@
 package almond
 
+import java.io.{ByteArrayOutputStream, PrintStream}
 import java.net.{URL, URLClassLoader}
+import java.nio.charset.StandardCharsets
 import java.util.UUID
+
 import almond.amm.AlmondCompilerLifecycleManager
 import almond.channels.Channel
 import almond.interpreter.Message
@@ -11,7 +14,7 @@ import almond.kernel.{Kernel, KernelThreads}
 import almond.protocol.{Execute => ProtocolExecute, _}
 import almond.testkit.{ClientStreams, Dsl}
 import almond.testkit.TestLogging.logCtx
-import almond.TestUtil.{IOOps, KernelOps, isScala212, execute => executeMessage}
+import almond.TestUtil.{IOOps, KernelOps, execute => executeMessage, isScala212}
 import almond.util.SequentialExecutionContext
 import almond.util.ThreadUtil.{attemptShutdownExecutionContext, singleThreadedExecutionContext}
 import ammonite.util.Colors
@@ -19,8 +22,6 @@ import cats.effect.IO
 import fs2.Stream
 import utest._
 
-import java.io.{ByteArrayOutputStream, PrintStream}
-import java.nio.charset.StandardCharsets
 import scala.collection.JavaConverters._
 import scala.collection.compat._
 

--- a/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
@@ -58,6 +58,8 @@ final case class Options(
   metabrowse: Boolean = false,
   @HelpMessage("Trap what user code sends to stdout and stderr")
   trapOutput: Boolean = false,
+  @HelpMessage("If false, duplicates stdout/stderr to console, similar to IPKernelApp.quiet")
+  quiet: Boolean = true,
   @HelpMessage("Disable ammonite compilation cache")
   disableCache: Boolean = false,
   @HelpMessage("Whether to automatically update lazy val-s upon computation")

--- a/modules/scala/scala-kernel/src/main/scala/almond/ScalaKernel.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/ScalaKernel.scala
@@ -167,6 +167,7 @@ object ScalaKernel extends CaseApp[Options] {
         metabrowsePort = -1,
         lazyInit = true,
         trapOutput = options.trapOutput,
+        quiet = options.quiet,
         disableCache = options.disableCache,
         autoUpdateLazyVals = options.autoUpdateLazyVals,
         autoUpdateVars = options.autoUpdateVars,

--- a/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
+++ b/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
@@ -233,6 +233,29 @@ object Tests {
       )
     }
 
+  def quietOutput(consoleOut: => String, consoleErr: => String, quiet: Boolean)(implicit
+    sessionId: SessionId,
+    runner: Runner
+  ): Unit = {
+    runner.withSession() { implicit session =>
+      execute(
+        """System.err.print("test err"); System.out.print("test out")""",
+        "",
+        stdout = "test out",
+        stderr = "test err"
+      )
+
+      if (quiet) {
+        assert(!consoleOut.contains("test out"))
+        assert(!consoleErr.contains("test err"))
+      }
+      else {
+        assert(consoleOut.contains("test out"))
+        assert(consoleErr.contains("test err"))
+      }
+    }
+  }
+
   def lastException()(implicit sessionId: SessionId, runner: Runner): Unit =
     runner.withSession() { implicit session =>
       execute(


### PR DESCRIPTION
## What is changed

This PR introduces a new `quiet` interpreter parameter which controls mirroring stdout/stderr to console. This is similar to IPKernelApp.quiet parameter. It could be used to collect kernel's output and store it somewhere to make debugging things easier.

Another possible option to support this is to change the existing `trapOutput` flag from `Boolean` to `String` to support three modes: `trap`, `mirror`, `default`, but this would be a breaking change. I'm happy to go with that approach if you think that it's better to keep amount of flags low and you don't care that much about changing parameter name/type

## How is it tested
Manually with jupyterlab
New tests which capture console output and verify it