### PR TITLE
Add Fixes for Post-Interrupt Hook Feature

### DIFF
--- a/docs/pages/api-jupyter.md
+++ b/docs/pages/api-jupyter.md
@@ -174,19 +174,19 @@ lazy val sc = {
 }
 
 // Add new hook with name "CancelAllSparkJobs"
-kernel.addAfterInterruptHook(
+kernel.addPostInterruptHook(
   "CancelAllSparkJobs",
   _ => sc.cancelAllJobs()
 )
 
 // Return a list with all registered hooks
-kernel.afterInterruptHooks
+kernel.postInterruptHooks
 
 // Remove hook by name
-kernel.removeAfterInterruptHook("CancelAllSparkJobs")
+kernel.removePostInterruptHook("CancelAllSparkJobs")
 
 // Run after-interrupt hooks (called internally after a cell interrupt)
-kernel.runAfterInterruptHooks()
+kernel.runPostInterruptHooks()
 ```
 Since Scala anonymous functions don't print well after being compiled to bytecode
 each hook is registered with a name.

--- a/docs/pages/api-jupyter.md
+++ b/docs/pages/api-jupyter.md
@@ -172,10 +172,25 @@ lazy val spark = {
 lazy val sc = {
   spark.sparkContext
 }
-kernel.afterInterruptHooks += { _ =>
-  sc.cancelAllJobs()
-}
+
+// Add new hook with name "CancelAllSparkJobs"
+kernel.addAfterInterruptHook(
+  "CancelAllSparkJobs",
+  _ => sc.cancelAllJobs()
+)
+
+// Return a list with all registered hooks
+kernel.afterInterruptHooks
+
+// Remove hook by name
+kernel.removeAfterInterruptHook("CancelAllSparkJobs")
+
+// Run after-interrupt hooks (called internally after a cell interrupt)
+kernel.runAfterInterruptHooks()
 ```
+Since Scala anonymous functions don't print well after being compiled to bytecode
+each hook is registered with a name.
+
 
 ### Hooks
 

--- a/modules/scala/jupyter-api/src/main/scala/almond/api/JupyterApi.scala
+++ b/modules/scala/jupyter-api/src/main/scala/almond/api/JupyterApi.scala
@@ -57,10 +57,10 @@ abstract class JupyterApi { api =>
   def addExecuteHook(hook: JupyterApi.ExecuteHook): Boolean
   def removeExecuteHook(hook: JupyterApi.ExecuteHook): Boolean
 
-  def addAfterInterruptHook(name: String, hook: Any => Any): Boolean
-  def removeAfterInterruptHook(name: String): Boolean
-  def afterInterruptHooks(): Seq[(String, Any => Any)]
-  def runAfterInterruptHooks(): Unit
+  def addPostInterruptHook(name: String, hook: Any => Any): Boolean
+  def removePostInterruptHook(name: String): Boolean
+  def postInterruptHooks(): Seq[(String, Any => Any)]
+  def runPostInterruptHooks(): Unit
 
   def consoleOut: PrintStream
   def consoleErr: PrintStream

--- a/modules/scala/jupyter-api/src/main/scala/almond/api/JupyterApi.scala
+++ b/modules/scala/jupyter-api/src/main/scala/almond/api/JupyterApi.scala
@@ -57,6 +57,11 @@ abstract class JupyterApi { api =>
   def addExecuteHook(hook: JupyterApi.ExecuteHook): Boolean
   def removeExecuteHook(hook: JupyterApi.ExecuteHook): Boolean
 
+  def addAfterInterruptHook(name: String, hook: Any => Any): Boolean
+  def removeAfterInterruptHook(name: String): Boolean
+  def afterInterruptHooks(): Seq[(String, Any => Any)]
+  def runAfterInterruptHooks(): Unit
+
   def consoleOut: PrintStream
   def consoleErr: PrintStream
 }
@@ -143,6 +148,16 @@ object JupyterApi {
     def update(k: String, v: String, last: Boolean): Unit = {
       // temporary dummy implementation for binary compatibility
     }
+  }
+
+  // Convenience functions for facilitating JupyterApi instance access
+  private var japi: JupyterApi = null
+  def setInstance(jupyterApi: JupyterApi) = synchronized {
+    if (jupyterApi != null) japi = jupyterApi
+    else throw new Exception("fct 'setInstance': Cannot set instance to 'null'")
+  }
+  def getInstanceOpt: Option[JupyterApi] = synchronized {
+    if (japi != null) Some(japi) else None
   }
 
 }

--- a/modules/scala/jupyter-api/src/main/scala/almond/api/JupyterApi.scala
+++ b/modules/scala/jupyter-api/src/main/scala/almond/api/JupyterApi.scala
@@ -150,14 +150,4 @@ object JupyterApi {
     }
   }
 
-  // Convenience functions for facilitating JupyterApi instance access
-  private var japi: JupyterApi = null
-  def setInstance(jupyterApi: JupyterApi) = synchronized {
-    if (jupyterApi != null) japi = jupyterApi
-    else throw new Exception("fct 'setInstance': Cannot set instance to 'null'")
-  }
-  def getInstanceOpt: Option[JupyterApi] = synchronized {
-    if (japi != null) Some(japi) else None
-  }
-
 }

--- a/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
@@ -259,11 +259,11 @@ final class Execute(
               s"Received SIGINT, stopping thread $t\n${interruptedStackTraceOpt0.map("  " + _).mkString("\n")}"
             )
             if (useThreadInterrupt) {
-              log.debug(s"fct 'interruptible': Calling 'Thread.interrupt'")
+              log.debug(s"Calling 'Thread.interrupt'")
               t.interrupt()
             }
             else {
-              log.debug(s"fct 'interruptible': Calling 'Thread.stop'")
+              log.debug(s"Calling 'Thread.stop'")
               t.stop()
             }
 
@@ -286,11 +286,11 @@ final class Execute(
           s"Interrupt asked, stopping thread $t\n${t.getStackTrace.map("  " + _).mkString("\n")}"
         )
         if (useThreadInterrupt) {
-          log.debug(s"fct 'interrupt': Calling 'Thread.interrupt'")
+          log.debug(s"Calling 'Thread.interrupt'")
           t.interrupt()
         }
         else {
-          log.debug(s"fct 'interrupt': Calling 'Thread.stop'")
+          log.debug(s"Calling 'Thread.stop'")
           t.stop()
         }
 

--- a/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
@@ -34,7 +34,6 @@ import scala.cli.directivehandler.EitherSequence._
 import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.Duration
-import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 /** Wraps contextual things around when executing code (capturing output, stdin via front-ends,
@@ -269,11 +268,7 @@ final class Execute(
             }
 
             // Run post-interrupt hooks
-            try jupyterApi.runPostInterruptHooks()
-            catch {
-              case NonFatal(e) =>
-                log.warn("fct 'interruptible': Caught exception while running post-interrupt hooks", e)
-            }
+            jupyterApi.runPostInterruptHooks()
         }
       }.apply {
         t
@@ -300,11 +295,7 @@ final class Execute(
         }
 
         // Run post-interrupt hooks
-        try jupyterApi.runPostInterruptHooks()
-        catch {
-          case NonFatal(e) =>
-            log.warn("fct 'interrupt': Caught exception while trying to run post-interrupt hooks", e)
-        }
+        jupyterApi.runPostInterruptHooks()
     }
 
   private var lastExceptionOpt0 = Option.empty[Throwable]

--- a/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
@@ -271,7 +271,7 @@ final class Execute(
             // Run post-interrupt hooks
             JupyterApi.getInstanceOpt match {
               case Some(japi) => try {
-                japi.runAfterInterruptHooks()
+                japi.runPostInterruptHooks()
               } catch {
                 case NonFatal(e) =>
                   log.warn("fct 'interruptible': Caught exception while running post-interrupt hooks", e)
@@ -306,7 +306,7 @@ final class Execute(
         // Run post-interrupt hooks
         JupyterApi.getInstanceOpt match {
           case Some(japi) => try {
-            japi.runAfterInterruptHooks()
+            japi.runPostInterruptHooks()
           } catch {
             case NonFatal(e) =>
               log.warn("fct 'interrupt': Caught exception while trying to run post-interrupt hooks", e)

--- a/modules/scala/scala-interpreter/src/main/scala/almond/JupyterApiImpl.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/JupyterApiImpl.scala
@@ -91,24 +91,24 @@ final class JupyterApiImpl(
     }
   }
 
-  private val afterInterruptHooks0 = new mutable.ListBuffer[(String, Any => Any)]
-  def addAfterInterruptHook(name: String, hook: Any => Any): Boolean = {
-    !afterInterruptHooks0.map(_._1).contains((name)) && {
-      afterInterruptHooks0.append((name, hook))
+  private val postInterruptHooks0 = new mutable.ListBuffer[(String, Any => Any)]
+  def addPostInterruptHook(name: String, hook: Any => Any): Boolean = {
+    !postInterruptHooks0.map(_._1).contains((name)) && {
+      postInterruptHooks0.append((name, hook))
       true
     }
   }
-  def removeAfterInterruptHook(name: String): Boolean = {
-    val idx = afterInterruptHooks0.map(_._1).indexOf(name)
+  def removePostInterruptHook(name: String): Boolean = {
+    val idx = postInterruptHooks0.map(_._1).indexOf(name)
     idx >= 0 && {
-      afterInterruptHooks0.remove(idx)
+      postInterruptHooks0.remove(idx)
       true
     }
   }
-  def afterInterruptHooks(): Seq[(String, Any => Any)] = afterInterruptHooks0.toList
-  def runAfterInterruptHooks(): Unit = {
+  def postInterruptHooks(): Seq[(String, Any => Any)] = postInterruptHooks0.toList
+  def runPostInterruptHooks(): Unit = {
     try {
-      Function.chain(afterInterruptHooks0.map(_._2)).apply(())
+      Function.chain(postInterruptHooks0.map(_._2)).apply(())
     } catch {
       // Not able to import 'almond.logger.Logger' here, so need to report from caller. JVM will release the lock.
       case NonFatal(e) => throw (e)

--- a/modules/scala/scala-interpreter/src/main/scala/almond/JupyterApiImpl.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/JupyterApiImpl.scala
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets
 import almond.api.{FullJupyterApi, JupyterApi}
 import almond.internals.HtmlAnsiOutputStream
 import almond.interpreter.api.CommHandler
+import almond.logger.LoggerContext
 import ammonite.util.Ref
 import pprint.{TPrint, TPrintColors}
 
@@ -24,8 +25,11 @@ final class JupyterApiImpl(
   protected val allowVariableInspector: Option[Boolean],
   val kernelClassLoader: ClassLoader,
   val consoleOut: PrintStream,
-  val consoleErr: PrintStream
+  val consoleErr: PrintStream,
+  logCtx: LoggerContext
 ) extends FullJupyterApi with VariableInspectorApiImpl {
+
+  private val log = logCtx(getClass)
 
   protected def variableInspectorImplPPrinter() = replApi.pprinter()
 
@@ -110,8 +114,8 @@ final class JupyterApiImpl(
     try {
       Function.chain(postInterruptHooks0.map(_._2)).apply(())
     } catch {
-      // Not able to import 'almond.logger.Logger' here, so need to report from caller. JVM will release the lock.
-      case NonFatal(e) => throw (e)
+      case NonFatal(e) =>
+        log.warn("fct 'interruptible': Caught exception while running post-interrupt hooks", e)
     }
   }
 

--- a/modules/scala/scala-interpreter/src/main/scala/almond/JupyterApiImpl.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/JupyterApiImpl.scala
@@ -110,13 +110,11 @@ final class JupyterApiImpl(
     }
   }
   def postInterruptHooks(): Seq[(String, Any => Any)] = postInterruptHooks0.toList
-  def runPostInterruptHooks(): Unit = {
-    try {
-      Function.chain(postInterruptHooks0.map(_._2)).apply(())
-    } catch {
+  def runPostInterruptHooks(): Unit =
+    try Function.chain(postInterruptHooks0.map(_._2)).apply(())
+    catch {
       case NonFatal(e) =>
         log.warn("Caught exception while running post-interrupt hooks", e)
     }
-  }
 
 }

--- a/modules/scala/scala-interpreter/src/main/scala/almond/JupyterApiImpl.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/JupyterApiImpl.scala
@@ -115,7 +115,7 @@ final class JupyterApiImpl(
       Function.chain(postInterruptHooks0.map(_._2)).apply(())
     } catch {
       case NonFatal(e) =>
-        log.warn("fct 'interruptible': Caught exception while running post-interrupt hooks", e)
+        log.warn("Caught exception while running post-interrupt hooks", e)
     }
   }
 

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -1,6 +1,7 @@
 package almond
 
 import almond.amm.AmmInterpreter
+import almond.api.JupyterApi
 import almond.internals._
 import almond.interpreter._
 import almond.interpreter.api.{CommHandler, OutputHandler}
@@ -102,6 +103,7 @@ final class ScalaInterpreter(
       consoleOut = System.out,
       consoleErr = System.err
     )
+  JupyterApi.setInstance(jupyterApi)
 
   if (params.toreeMagics) {
     jupyterApi.addExecuteHook(LineMagicHook.hook(replApi.pprinter))
@@ -152,12 +154,6 @@ final class ScalaInterpreter(
     true
   override def interrupt(): Unit = {
     execute0.interrupt()
-
-    try Function.chain(jupyterApi.afterInterruptHooks).apply(())
-    catch {
-      case NonFatal(e) =>
-        log.warn("Caught exception while trying to run after Interrupt hooks", e)
-    }
   }
 
   override def supportComm: Boolean = true

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -101,7 +101,8 @@ final class ScalaInterpreter(
       params.allowVariableInspector,
       kernelClassLoader = Thread.currentThread().getContextClassLoader,
       consoleOut = System.out,
-      consoleErr = System.err
+      consoleErr = System.err,
+      logCtx = logCtx
     )
 
   if (params.toreeMagics) {

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -152,9 +152,8 @@ final class ScalaInterpreter(
 
   override def interruptSupported: Boolean =
     true
-  override def interrupt(): Unit = {
+  override def interrupt(): Unit =
     execute0.interrupt(jupyterApi)
-  }
 
   override def supportComm: Boolean = true
   override def setCommHandler(commHandler0: CommHandler): Unit =

--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -103,7 +103,6 @@ final class ScalaInterpreter(
       consoleOut = System.out,
       consoleErr = System.err
     )
-  JupyterApi.setInstance(jupyterApi)
 
   if (params.toreeMagics) {
     jupyterApi.addExecuteHook(LineMagicHook.hook(replApi.pprinter))
@@ -153,7 +152,7 @@ final class ScalaInterpreter(
   override def interruptSupported: Boolean =
     true
   override def interrupt(): Unit = {
-    execute0.interrupt()
+    execute0.interrupt(jupyterApi)
   }
 
   override def supportComm: Boolean = true
@@ -173,7 +172,8 @@ final class ScalaInterpreter(
       outputHandler,
       colors0,
       storeHistory,
-      jupyterApi.executeHooks
+      jupyterApi.executeHooks,
+      jupyterApi
     )
 
   def currentLine(): Int =


### PR DESCRIPTION
This is a rework of https://github.com/almond-sh/almond/pull/1186 to make the post-interrupt hook feature work as intended:

- Added abstract functions to ‘JupyterApi.scala’ to make interface visible to Ammonite kernel object
- Added API usage examples to ‘api-jupyter.md’
- Added convenience functions for facilitating JupyterApi instance access,
   since it is hard to pass around through function/method calls. In case at
   hand, we need to access it from methods ‘interruptible’ and ‘interrupt’ in
   class ‘Execute’
- Added a label field to each registered hook, since Scala lambda functions
  are not easy to print in human readable form
- Did local testing of API  both when sending interrupt messages via SIGINT or via 
  zeromq message, i.e. without/with '--interrupt-via-message’)


Note: Contrary to execution hooks, interrupt hooks do not at present funnel output
from one hook into the input of the next in the chain.

Please find screenshots from local testing attached below.

<img width="1248" alt="Screenshot 2023-08-13 at 6 55 27 AM" src="https://github.com/almond-sh/almond/assets/1687321/9804bd77-cc73-40c4-8970-3395ba54a083">
<img width="1089" alt="Screenshot 2023-08-13 at 6 54 09 AM" src="https://github.com/almond-sh/almond/assets/1687321/7750906a-bf1f-46f8-a3f6-e9aa3f894819">
<img width="1225" alt="Screenshot 2023-08-13 at 6 56 10 AM" src="https://github.com/almond-sh/almond/assets/1687321/58346726-d751-49c1-8cd1-58f695d1574d">
