### PR TITLE
Stay on macos-12 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           - OS: windows-latest
             JDK: 8
             SCALA: 2.13.12
-          - OS: macos-latest
+          - OS: macos-12
             JDK: 8
             SCALA: 2.13.12
           - OS: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        OS: ["ubuntu-22.04", macos-latest, windows-latest]
+        OS: ["ubuntu-22.04", macos-12, windows-latest]
     steps:
     - name: Don't convert LF to CRLF during checkout
       if: runner.os == 'Windows'


### PR DESCRIPTION
Seems the new macos-14 images are on ARM64, which has no Java 8. We can think later about updating the JVM in the tests.