### PR TITLE
revert to cmd for the wrapper name

### DIFF
--- a/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup213.scala
+++ b/modules/scala/integration/src/test/scala/almond/integration/KernelTestsTwoStepStartup213.scala
@@ -30,7 +30,7 @@ class KernelTestsTwoStepStartup213 extends KernelTestsDefinitions {
             |""".stripMargin,
           expectError = true,
           stderr =
-            """cell2.sc:6: method foo in class Helper is deprecated
+            """cmd2.sc:6: method foo in class Helper is deprecated
               |val res2_1 = foo()
               |             ^
               |No warnings can be incurred under -Werror.
@@ -63,7 +63,7 @@ class KernelTestsTwoStepStartup213 extends KernelTestsDefinitions {
             |""".stripMargin,
           expectError = true,
           stderr =
-            """cell2.sc:4: method foo in class Helper is deprecated
+            """cmd2.sc:4: method foo in class Helper is deprecated
               |val res2_1 = foo()
               |             ^
               |No warnings can be incurred under -Werror.
@@ -92,7 +92,7 @@ class KernelTestsTwoStepStartup213 extends KernelTestsDefinitions {
              |""".stripMargin,
           expectError = true,
           stderr =
-            """cell1.sc:7: method foo in class Helper is deprecated
+            """cmd1.sc:7: method foo in class Helper is deprecated
               |val res1_1 = foo()
               |             ^
               |No warnings can be incurred under -Werror.
@@ -127,7 +127,7 @@ class KernelTestsTwoStepStartup213 extends KernelTestsDefinitions {
             |""".stripMargin,
           expectError = true,
           stderr =
-            """cell2.sc:6: method foo in class Helper is deprecated
+            """cmd2.sc:6: method foo in class Helper is deprecated
               |val res2_1 = foo()
               |             ^
               |No warnings can be incurred under -Xfatal-warnings.
@@ -162,7 +162,7 @@ class KernelTestsTwoStepStartup213 extends KernelTestsDefinitions {
             |""".stripMargin,
           expectError = true,
           stderr =
-            """cell2.sc:6: method foo in class Helper is deprecated
+            """cmd2.sc:6: method foo in class Helper is deprecated
               |val res2_1 = foo()
               |             ^
               |No warnings can be incurred under -Xfatal-warnings.

--- a/modules/scala/scala-interpreter/src/main/scala/almond/amm/AmmInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/amm/AmmInterpreter.scala
@@ -59,7 +59,9 @@ object AmmInterpreter {
 
   /* Spark 3.5.1 expects `cmd` in `org.apache.spark.sql.catalyst.encoders.OuterScopes`.
    * This name is confusing to users and `cell` is more obvious. However, that change depends
-   * on an update to the spark regex.
+   * on customizing the `CodeClassWrapper` so
+   * `org.apache.spark.sql.catalyst.encoders.OuterScopes.addOuterScope(this)`
+   * calls are automatically added. Or, less preferably, changing the regex in Spark.
    */
   private def ammoniteWrapperNamePrefix = "cmd"
 

--- a/modules/scala/scala-interpreter/src/main/scala/almond/amm/AmmInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/amm/AmmInterpreter.scala
@@ -57,6 +57,12 @@ object AmmInterpreter {
     ImportData("almond.toree.ToreeCompatibility.KernelToreeOps")
   )
 
+  /* Spark 3.5.1 expects `cmd` in `org.apache.spark.sql.catalyst.encoders.OuterScopes`.
+   * This name is confusing to users and `cell` is more obvious. However, that change depends
+   * on an update to the spark regex.
+   */
+  private def ammoniteWrapperNamePrefix = "cmd"
+
   /** Instantiate an [[ammonite.interp.Interpreter]] to be used from [[ScalaInterpreter]].
     */
   def apply(
@@ -139,7 +145,7 @@ object AmmInterpreter {
         verboseOutput = true, // ???
         alreadyLoadedDependencies =
           ammonite.main.Defaults.alreadyLoadedDependencies("almond/almond-user-dependencies.txt"),
-        wrapperNamePrefix = "cell"
+        wrapperNamePrefix = ammoniteWrapperNamePrefix
       )
       val outputDir0 = outputDir match {
         case Left(path)   => Some(path.toNIO)

--- a/modules/scala/scala-kernel/src/test/scala/almond/ScalafmtTests.scala
+++ b/modules/scala/scala-kernel/src/test/scala/almond/ScalafmtTests.scala
@@ -125,7 +125,7 @@ object ScalafmtTests extends TestSuite {
       val expectedCode = formattedSnippet1
 
       val request = Format.Request(ListMap(
-        "cell1" -> initialCode
+        "cmd1" -> initialCode
       ))
       val messages0       = messages(scalafmt, request)
       val processMessages = endsWithFormatReply(messages0)
@@ -134,8 +134,8 @@ object ScalafmtTests extends TestSuite {
       println(formattedCodeMap)
 
       val resp = formattedCodeMap.getOrElse(
-        "cell1",
-        sys.error("No data for key 'cell1' in response")
+        "cmd1",
+        sys.error("No data for key 'cmd1' in response")
       )
       assert(resp.initial_code == initialCode)
       val formattedCode = resp.code.getOrElse {
@@ -146,8 +146,8 @@ object ScalafmtTests extends TestSuite {
 
     test("multiple cells") {
       val request = Format.Request(ListMap(
-        "cell1" -> snippet1,
-        "cell2" -> snippet2
+        "cmd1" -> snippet1,
+        "cmd2" -> snippet2
       ))
       val messages0       = messages(scalafmt, request)
       val processMessages = endsWithFormatReply(messages0)
@@ -156,8 +156,8 @@ object ScalafmtTests extends TestSuite {
       println(formattedCodeMap)
 
       val resp1 = formattedCodeMap.getOrElse(
-        "cell1",
-        sys.error("No data for key 'cell1' in response")
+        "cmd1",
+        sys.error("No data for key 'cmd1' in response")
       )
       assert(resp1.initial_code == snippet1)
       val formattedCode1 = resp1.code.getOrElse {
@@ -166,8 +166,8 @@ object ScalafmtTests extends TestSuite {
       assert(formattedCode1 == formattedSnippet1)
 
       val resp2 = formattedCodeMap.getOrElse(
-        "cell2",
-        sys.error("No data for key 'cell2' in response")
+        "cmd2",
+        sys.error("No data for key 'cmd2' in response")
       )
       assert(resp2.initial_code == snippet2)
       val formattedCode2 = resp2.code.getOrElse {

--- a/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
+++ b/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
@@ -748,19 +748,19 @@ object Tests {
           |  ^
           |Compilation Failed""".stripMargin
       else
-        """-- [E006] Not Found Error: cmd1.sc:2:2 ----------------------------------------
+        """-- [E006] Not Found Error: cmd1.sc:2:2 -----------------------------------------
           |2 |  foo
           |  |  ^^^
           |  |  Not found: foo
           |  |
           |  | longer explanation available when compiling with `-explain`
-          |-- [E006] Not Found Error: cmd1.sc:3:2 ----------------------------------------
+          |-- [E006] Not Found Error: cmd1.sc:3:2 -----------------------------------------
           |3 |  bar
           |  |  ^^^
           |  |  Not found: bar
           |  |
           |  | longer explanation available when compiling with `-explain`
-          |-- [E006] Not Found Error: cmd1.sc:4:2 ----------------------------------------
+          |-- [E006] Not Found Error: cmd1.sc:4:2 -----------------------------------------
           |4 |  other
           |  |  ^^^^^
           |  |  Not found: other
@@ -852,7 +852,7 @@ object Tests {
             |Compilation Failed""".stripMargin
         else
           // FIXME The line number is wrong here
-          """-- Error: cmd2.sc:3:8 ---------------------------------------------------------
+          """-- Error: cmd2.sc:3:8 ----------------------------------------------------------
             |3 |val n = getValue()
             |  |        ^^^^^^^^
             |  |        method getValue in class Helper is deprecated since 0.1: foo

--- a/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
+++ b/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
@@ -737,30 +737,30 @@ object Tests {
 
     val errorOutput =
       if (scalaVersion.startsWith("2."))
-        """cell1.sc:2: not found: value foo
+        """cmd1.sc:2: not found: value foo
           |  foo
           |  ^
-          |cell1.sc:3: not found: value bar
+          |cmd1.sc:3: not found: value bar
           |  bar
           |  ^
-          |cell1.sc:4: not found: value other
+          |cmd1.sc:4: not found: value other
           |  other
           |  ^
           |Compilation Failed""".stripMargin
       else
-        """-- [E006] Not Found Error: cell1.sc:2:2 ----------------------------------------
+        """-- [E006] Not Found Error: cmd1.sc:2:2 ----------------------------------------
           |2 |  foo
           |  |  ^^^
           |  |  Not found: foo
           |  |
           |  | longer explanation available when compiling with `-explain`
-          |-- [E006] Not Found Error: cell1.sc:3:2 ----------------------------------------
+          |-- [E006] Not Found Error: cmd1.sc:3:2 ----------------------------------------
           |3 |  bar
           |  |  ^^^
           |  |  Not found: bar
           |  |
           |  | longer explanation available when compiling with `-explain`
-          |-- [E006] Not Found Error: cell1.sc:4:2 ----------------------------------------
+          |-- [E006] Not Found Error: cmd1.sc:4:2 ----------------------------------------
           |4 |  other
           |  |  ^^^^^
           |  |  Not found: other
@@ -839,20 +839,20 @@ object Tests {
 
       val errorMessage =
         if (scalaVersion.startsWith("2.13."))
-          """cell2.sc:4: method getValue in class Helper is deprecated (since 0.1): foo
+          """cmd2.sc:4: method getValue in class Helper is deprecated (since 0.1): foo
             |val n = getValue()
             |        ^
             |No warnings can be incurred under -Werror.
             |Compilation Failed""".stripMargin
         else if (scalaVersion.startsWith("2.12."))
-          """cell2.sc:4: method getValue in class Helper is deprecated (since 0.1): foo
+          """cmd2.sc:4: method getValue in class Helper is deprecated (since 0.1): foo
             |val n = getValue()
             |        ^
             |No warnings can be incurred under -Xfatal-warnings.
             |Compilation Failed""".stripMargin
         else
           // FIXME The line number is wrong here
-          """-- Error: cell2.sc:3:8 ---------------------------------------------------------
+          """-- Error: cmd2.sc:3:8 ---------------------------------------------------------
             |3 |val n = getValue()
             |  |        ^^^^^^^^
             |  |        method getValue in class Helper is deprecated since 0.1: foo


### PR DESCRIPTION
This is the name expected by Spark.