### PR TITLE
Drop support for 2.12.{16,17}, 2.13.10, and 3.3.0

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -76,7 +76,7 @@ object Deps {
 
 object ScalaVersions {
   def scala3Latest   = "3.4.2"
-  def scala3Compat   = "3.3.0"
+  def scala3Compat   = "3.3.1"
   def scala213       = "2.13.14"
   def scala212       = "2.12.19"
   val binaries       = Seq(scala3Compat, scala213, scala212)
@@ -85,17 +85,13 @@ object ScalaVersions {
     scala3Latest,
     "3.3.3",
     "3.3.2",
-    "3.3.1",
     scala3Compat,
     scala213,
     "2.13.13",
     "2.13.12",
     "2.13.11",
-    "2.13.10",
     scala212,
-    "2.12.18",
-    "2.12.17",
-    "2.12.16"
+    "2.12.18"
   ).distinct
 
   def binary(sv: String) =


### PR DESCRIPTION
Quite old versions, plus they crash 'shared.test-kit[…].compile' on JDK 21 or other compilation tasks