### PR TITLE
Add ability to bind to random ports (0.14.1)

### DIFF
--- a/modules/echo/src/main/scala/almond/echo/EchoKernel.scala
+++ b/modules/echo/src/main/scala/almond/echo/EchoKernel.scala
@@ -8,6 +8,8 @@ import almond.logger.{Level, LoggerContext}
 import caseapp._
 import cats.effect.unsafe.IORuntime
 
+import java.nio.file.Paths
+
 object EchoKernel extends CaseApp[Options] {
 
   def run(options: Options, args: RemainingArgs): Unit = {
@@ -59,7 +61,10 @@ object EchoKernel extends CaseApp[Options] {
         zeromqThreads,
         Nil,
         autoClose = true,
-        lingerDuration = options.lingerDuration
+        lingerDuration = options.lingerDuration,
+        bindToRandomPorts =
+          if (options.bindToRandomPorts.getOrElse(true)) Some(Paths.get(connectionFile))
+          else None
       ))
       .unsafeRunSync()(IORuntime.global)
   }

--- a/modules/echo/src/main/scala/almond/echo/Options.scala
+++ b/modules/echo/src/main/scala/almond/echo/Options.scala
@@ -20,7 +20,13 @@ final case class Options(
     """Time given to the client to accept ZeroMQ messages before exiting. Parsed with scala.concurrent.duration.Duration, this accepts things like "Inf" or "5 seconds""""
   )
   @Hidden
-    linger: Option[String] = None
+    linger: Option[String] = None,
+
+  @HelpMessage(
+    "If zero-d ports are passed by Jupyter in connection file, bind to random available ports, " +
+    "and update the connection file with the actually used ports"
+  )
+    bindToRandomPorts: Option[Boolean] = None
 ) {
   // format: on
 

--- a/modules/scala/launcher/src/main/scala/almond/launcher/Launcher.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/Launcher.scala
@@ -22,6 +22,7 @@ import dependency.ScalaParameters
 
 import java.io.{File, FileOutputStream, PrintStream}
 import java.nio.channels.ClosedSelectorException
+import java.nio.file.Paths
 
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
@@ -329,7 +330,10 @@ object Launcher extends CaseApp[LauncherOptions] {
         zeromqThreads,
         Nil,
         autoClose = false,
-        lingerDuration = Duration.Inf // unused here
+        lingerDuration = Duration.Inf, // unused here
+        bindToRandomPorts =
+          if (options.bindToRandomPorts.getOrElse(true)) Some(Paths.get(connectionFile))
+          else None
       ))
       .unsafeRunSync()(IORuntime.global)
     val leftoverMessages: Seq[(Channel, RawMessage)] = run.unsafeRunSync()(IORuntime.global)

--- a/modules/scala/launcher/src/main/scala/almond/launcher/LauncherOptions.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/LauncherOptions.scala
@@ -38,7 +38,12 @@ final case class LauncherOptions(
   customDirectiveGroup: List[String] = Nil,
   @HelpMessage("Time given to the client to accept ZeroMQ messages before handing over the connections to the kernel. Parsed with scala.concurrent.duration.Duration, this accepts things like \"Inf\" or \"5 seconds\"")
   @Hidden
-    linger: Option[String] = None
+    linger: Option[String] = None,
+  @HelpMessage(
+    "If zero-d ports are passed by Jupyter in connection file, bind to random available ports, " +
+    "and update the connection file with the actually used ports"
+  )
+    bindToRandomPorts: Option[Boolean] = None
 ) {
   // format: on
 

--- a/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
@@ -134,7 +134,13 @@ final case class Options(
 
   @HelpMessage("""Time given to the client to accept ZeroMQ messages before exiting. Parsed with scala.concurrent.duration.Duration, this accepts things like "Inf" or "5 seconds"""")
   @Hidden
-    linger: Option[String] = None
+    linger: Option[String] = None,
+
+  @HelpMessage(
+    "If zero-d ports are passed by Jupyter in connection file, bind to random available ports, " +
+    "and update the connection file with the actually used ports"
+  )
+    bindToRandomPorts: Option[Boolean] = None
 ) {
   // format: on
 

--- a/modules/scala/scala-kernel/src/main/scala/almond/ScalaKernel.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/ScalaKernel.scala
@@ -15,6 +15,8 @@ import caseapp._
 import cats.effect.unsafe.IORuntime
 import coursier.cputil.ClassPathUtil
 
+import java.nio.file.Paths
+
 import scala.language.reflectiveCalls
 import scala.concurrent.ExecutionContext
 import scala.util.Properties
@@ -253,7 +255,10 @@ object ScalaKernel extends CaseApp[Options] {
           zeromqThreads,
           options.leftoverMessages0(),
           autoClose = true,
-          lingerDuration = options.lingerDuration
+          lingerDuration = options.lingerDuration,
+          bindToRandomPorts =
+            if (options.bindToRandomPorts.getOrElse(true)) Some(Paths.get(connectionFile))
+            else None
         ))
         .unsafeRunSync()(IORuntime.global)
     finally

--- a/modules/shared/channels/src/main/scala/almond/channels/Connection.scala
+++ b/modules/shared/channels/src/main/scala/almond/channels/Connection.scala
@@ -10,8 +10,11 @@ abstract class Connection {
   /** Open the channels.
     *
     * Must be run prior to [[send]], [[tryRead]], [[stream]], [[sink]].
+    *
+    * @return
+    *   map of ports that were chosen randomly. None key is for heartbeat port.
     */
-  def open: IO[Unit]
+  def open: IO[Map[Option[Channel], Int]]
 
   /** Send a message through a channel.
     *

--- a/modules/shared/channels/src/main/scala/almond/channels/ConnectionParameters.scala
+++ b/modules/shared/channels/src/main/scala/almond/channels/ConnectionParameters.scala
@@ -42,9 +42,18 @@ final case class ConnectionParameters(
     threads: ZeromqThreads,
     lingerPeriod: Option[Duration],
     logCtx: LoggerContext,
+    bindToRandomPorts: Boolean,
     identityOpt: Option[String] = None
   ): IO[ZeromqConnection] =
-    ZeromqConnection(this, bind, identityOpt, threads, lingerPeriod, logCtx)
+    ZeromqConnection(
+      this,
+      bind,
+      identityOpt,
+      threads,
+      lingerPeriod,
+      logCtx,
+      bindToRandomPorts = bindToRandomPorts
+    )
 
 }
 
@@ -83,5 +92,25 @@ object ConnectionParameters {
       Some("hmac-sha256")
     )
   }
+
+  /** Creates fresh connection parameters with a random key and zero-d ports
+    *
+    * Ports to zero are meant to be picked randomly by the kernel when it starts (see
+    * --bind-to-random-ports option)
+    *
+    * @return
+    */
+  def randomZeroPorts(): ConnectionParameters =
+    ConnectionParameters(
+      ip = "localhost",
+      transport = "tcp",
+      stdin_port = 0,
+      control_port = 0,
+      hb_port = 0,
+      shell_port = 0,
+      iopub_port = 0,
+      key = Secret.randomUuid(),
+      signature_scheme = Some("hmac-sha256")
+    )
 
 }

--- a/modules/shared/channels/src/main/scala/almond/channels/zeromq/ZeromqConnection.scala
+++ b/modules/shared/channels/src/main/scala/almond/channels/zeromq/ZeromqConnection.scala
@@ -1,5 +1,6 @@
 package almond.channels.zeromq
 
+import java.net.URI
 import java.nio.channels.{ClosedByInterruptException, Selector}
 import java.nio.charset.StandardCharsets.UTF_8
 
@@ -12,6 +13,7 @@ import org.zeromq.{SocketType, ZMQ, ZMQException}
 import org.zeromq.ZMQ.{PollItem, Poller}
 import zmq.ZError
 
+import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 
 final class ZeromqConnection(
@@ -20,7 +22,8 @@ final class ZeromqConnection(
   identityOpt: Option[String],
   threads: ZeromqThreads,
   lingerPeriod: Option[Duration],
-  logCtx: LoggerContext
+  logCtx: LoggerContext,
+  bindToRandomPorts: Boolean
 ) extends Connection {
 
   import ZeromqConnection._
@@ -51,7 +54,8 @@ final class ZeromqConnection(
     params.key,
     params.signature_scheme.getOrElse(defaultSignatureScheme),
     lingerPeriod,
-    logCtx
+    logCtx,
+    bindToRandomPort = bindToRandomPorts
   )
 
   private val control0 = ZeromqSocket(
@@ -65,7 +69,8 @@ final class ZeromqConnection(
     params.key,
     params.signature_scheme.getOrElse(defaultSignatureScheme),
     lingerPeriod,
-    logCtx
+    logCtx,
+    bindToRandomPort = bindToRandomPorts
   )
 
   private val publish0 = ZeromqSocket(
@@ -79,7 +84,8 @@ final class ZeromqConnection(
     params.key,
     params.signature_scheme.getOrElse(defaultSignatureScheme),
     lingerPeriod,
-    logCtx
+    logCtx,
+    bindToRandomPort = bindToRandomPorts
   )
 
   private val stdin0 = ZeromqSocket(
@@ -93,9 +99,17 @@ final class ZeromqConnection(
     params.key,
     params.signature_scheme.getOrElse(defaultSignatureScheme),
     lingerPeriod,
-    logCtx
+    logCtx,
+    bindToRandomPort = bindToRandomPorts
   )
 
+  private val heartBeatPortPromiseAndUri = {
+    lazy val parsedUri = new URI(params.heartbeatUri)
+    if (bind && bindToRandomPorts && parsedUri.getPort <= 0)
+      Some((Promise[Int](), ZeromqSocketImpl.removePort(parsedUri).toASCIIString))
+    else
+      None
+  }
   private val heartBeatThreadOpt: Option[Thread] =
     if (bind)
       Some(
@@ -112,7 +126,13 @@ final class ZeromqConnection(
             val heartbeat = threads.context.socket(repReq)
 
             heartbeat.setLinger(1000)
-            heartbeat.bind(params.heartbeatUri)
+            heartBeatPortPromiseAndUri match {
+              case Some((promise, uri0)) =>
+                val port = heartbeat.bindToRandomPort(uri0)
+                promise.success(port)
+              case None =>
+                heartbeat.bind(params.heartbeatUri)
+            }
 
             try
               while (true) {
@@ -147,18 +167,24 @@ final class ZeromqConnection(
         throw new Exception("Channel not opened")
     }
 
-  val open: IO[Unit] = {
+  val open: IO[Map[Option[Channel], Int]] = {
 
     val log0 = IO(log.debug(s"Opening channels for $params"))
 
-    val channels = Seq(
-      requests0,
-      control0,
-      publish0,
-      stdin0
+    val channels = Seq[(Channel, ZeromqSocket)](
+      Channel.Requests -> requests0,
+      Channel.Control  -> control0,
+      Channel.Publish  -> publish0,
+      Channel.Input    -> stdin0
     )
 
-    val t = channels.foldLeft(IO.unit)((acc, c) => acc *> c.open)
+    val t = channels.foldLeft(IO.pure(Map.empty[Option[Channel], Int])) {
+      case (acc, (channel, socket)) =>
+        for {
+          map     <- acc
+          portOpt <- socket.open
+        } yield map ++ portOpt.map((Some(channel), _)).toSeq
+    }
 
     val other = IO {
       synchronized {
@@ -169,7 +195,19 @@ final class ZeromqConnection(
       }
     }.evalOn(threads.selectorOpenCloseEc)
 
-    log0 *> t *> other
+    val maybeHeartBeatPort = heartBeatPortPromiseAndUri match {
+      case Some((promise, _)) =>
+        IO.fromFuture(IO.pure(promise.future)).map(port => Seq(None -> port))
+      case None =>
+        IO.pure(Nil)
+    }
+
+    for {
+      _          <- log0
+      ports      <- t
+      _          <- other
+      extraPorts <- maybeHeartBeatPort
+    } yield ports ++ extraPorts
   }
 
   def send(channel: Channel, message: Message): IO[Unit] = {
@@ -243,7 +281,8 @@ object ZeromqConnection {
     identityOpt: Option[String],
     threads: ZeromqThreads,
     lingerPeriod: Option[Duration],
-    logCtx: LoggerContext
+    logCtx: LoggerContext,
+    bindToRandomPorts: Boolean
   ): IO[ZeromqConnection] =
     IO(
       new ZeromqConnection(
@@ -252,7 +291,8 @@ object ZeromqConnection {
         identityOpt,
         threads,
         lingerPeriod,
-        logCtx
+        logCtx,
+        bindToRandomPorts = bindToRandomPorts
       )
     ).evalOn(threads.selectorOpenCloseEc)
 

--- a/modules/shared/channels/src/main/scala/almond/channels/zeromq/ZeromqSocket.scala
+++ b/modules/shared/channels/src/main/scala/almond/channels/zeromq/ZeromqSocket.scala
@@ -10,7 +10,11 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
 
 trait ZeromqSocket {
-  def open: IO[Unit]
+
+  /** @return
+    *   Randomly chosen port, if the port was picked this way
+    */
+  def open: IO[Option[Int]]
   def read: IO[Option[Message]]
   def send(message: Message): IO[Unit]
   def close(lingerDuration: Duration): IO[Unit]
@@ -34,7 +38,8 @@ object ZeromqSocket {
     key: Secret[String],
     algorithm: String,
     lingerPeriod: Option[Duration],
-    logCtx: LoggerContext
+    logCtx: LoggerContext,
+    bindToRandomPort: Boolean
   ): ZeromqSocket =
     new ZeromqSocketImpl(
       ec,
@@ -47,7 +52,8 @@ object ZeromqSocket {
       key,
       algorithm,
       lingerPeriod,
-      logCtx
+      logCtx,
+      bindToRandomPort = bindToRandomPort
     )
 
 }

--- a/modules/shared/channels/src/test/scala/almond/channels/zeromq/ZeromqConnectionTests.scala
+++ b/modules/shared/channels/src/test/scala/almond/channels/zeromq/ZeromqConnectionTests.scala
@@ -31,11 +31,13 @@ object ZeromqConnectionTests extends TestSuite {
 
       val t =
         for {
-          kernel <- params.channels(bind = true, kernelThreads, None, logCtx)
-          server <- params.channels(bind = false, serverThreads, None, logCtx)
-          _      <- kernel.open
-          _      <- server.open
-          _      <- server.send(Channel.Requests, msg0)
+          kernel <-
+            params.channels(bind = true, kernelThreads, None, logCtx, bindToRandomPorts = false)
+          server <-
+            params.channels(bind = false, serverThreads, None, logCtx, bindToRandomPorts = false)
+          _ <- kernel.open
+          _ <- server.open
+          _ <- server.send(Channel.Requests, msg0)
           resp <- kernel.tryRead(Seq(Channel.Requests), 1.second).flatMap {
             case Some(r) => IO.pure(r)
             case None    => IO.raiseError(new Exception("no message"))

--- a/modules/shared/channels/src/test/scala/almond/channels/zeromq/ZeromqSocketTests.scala
+++ b/modules/shared/channels/src/test/scala/almond/channels/zeromq/ZeromqSocketTests.scala
@@ -54,7 +54,8 @@ object ZeromqSocketTests extends TestSuite {
         key,
         "hmac-sha256",
         None,
-        logCtx
+        logCtx,
+        bindToRandomPort = false
       )
 
       val req = ZeromqSocket(
@@ -68,7 +69,8 @@ object ZeromqSocketTests extends TestSuite {
         key,
         "hmac-sha256",
         None,
-        logCtx
+        logCtx,
+        bindToRandomPort = false
       )
 
       val msg = Message(
@@ -119,7 +121,8 @@ object ZeromqSocketTests extends TestSuite {
         key,
         "hmac-sha256",
         None,
-        logCtx
+        logCtx,
+        bindToRandomPort = false
       )
 
       val req = ZeromqSocket(
@@ -133,7 +136,8 @@ object ZeromqSocketTests extends TestSuite {
         key,
         "hmac-sha256",
         None,
-        logCtx
+        logCtx,
+        bindToRandomPort = false
       )
 
       val msg = Message(


### PR DESCRIPTION
Backport of https://github.com/almond-sh/almond/pull/1557

---

This adds a `--bind-to-random-ports` option, which is enabled by default (can be disabled with `--bind-to-random-ports=false`). This option makes Almond accept connection files with one or more ports set to `0`. When that's the case, Almond asks zeromq to pick a random port to bind to, which works around race conditions where: Jupyter, or the app launching the kernel, picks random available ports, passes them to Almond in a connection file, and another concurrent app uses those port before Almond binds to them.

Connection files with ports set to `0` are then used by default in the integration tests here, to ensure it all works.

Fixes https://github.com/almond-sh/almond/issues/1502