### PR TITLE
Allow users to add payloads to execute reply messages (0.14.1)

### DIFF
--- a/modules/scala/launcher/src/main/scala/almond/launcher/LauncherOutputHandler.scala
+++ b/modules/scala/launcher/src/main/scala/almond/launcher/LauncherOutputHandler.scala
@@ -104,4 +104,7 @@ class LauncherOutputHandler(
   def canOutput(): Boolean = true
 
   def messageIdOpt: Option[String] = None
+
+  def addPayload(payload: String): Unit =
+    sys.error("Payloads not supported at that point")
 }

--- a/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/Execute.scala
@@ -23,7 +23,7 @@ import ammonite.compiler.Parsers
 import ammonite.repl.api.History
 import ammonite.repl.{Repl, Signaller}
 import ammonite.runtime.Storage
-import ammonite.util.{Colors, Ex, Printer, Ref, Res}
+import ammonite.util.{Colors, Evaluated, Ex, Printer, Ref, Res}
 import coursierapi.{IvyRepository, MavenRepository}
 import dependency.ScalaParameters
 import dependency.api.ops._

--- a/modules/scala/scala-interpreter/src/test/scala/almond/MockOutputHandler.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/MockOutputHandler.scala
@@ -26,4 +26,6 @@ class MockOutputHandler extends OutputHandler {
   def updateDisplay(displayData: almond.interpreter.api.DisplayData): Unit = ()
   def canOutput(): Boolean                                                 = false
   def messageIdOpt: Option[String]                                         = None
+
+  def addPayload(payload: String): Unit = ()
 }

--- a/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
+++ b/modules/scala/scala-interpreter/src/test/scala/almond/ScalaKernelTests.scala
@@ -876,6 +876,44 @@ object ScalaKernelTests extends TestSuite {
       implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
       almond.integration.Tests.toreeCustomCellMagic()
     }
+
+    test("payloads") {
+
+      val interpreter = new ScalaInterpreter(
+        params = ScalaInterpreterParams(
+          initialColors = Colors.BlackWhite
+        ),
+        logCtx = logCtx
+      )
+
+      val kernel = Kernel.create(interpreter, interpreterEc, threads, logCtx)
+        .unsafeRunTimedOrThrow()
+
+      implicit val sessionId: Dsl.SessionId = Dsl.SessionId()
+
+      val tq = "\"\"\""
+
+      // simple payload
+      kernel.execute(
+        """publish.addPayload("{}")""",
+        "",
+        replyPayloads = Seq("{}")
+      )
+
+      // multiple payloads
+      kernel.execute(
+        s"""publish.addPayload($tq{"source": "foo"}$tq); publish.addPayload($tq{"source": "thing"}$tq)""",
+        "",
+        replyPayloads = Seq("""{"source": "foo"}""", """{"source": "thing"}""")
+      )
+
+      // payload in cell that throws an exception
+      kernel.execute(
+        s"""publish.addPayload($tq{"source": "other"}$tq); throw new Exception("foo")""",
+        replyPayloads = Seq("""{"source": "other"}"""),
+        expectError = true
+      )
+    }
   }
 
 }

--- a/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/OutputHandler.scala
+++ b/modules/shared/interpreter-api/src/main/scala/almond/interpreter/api/OutputHandler.scala
@@ -28,6 +28,16 @@ abstract class OutputHandler extends OutputHandler.Helpers with OutputHandler.Up
     */
   def display(displayData: DisplayData): Unit
 
+  /** Adds a payload to be sent in the execute reply message
+    *
+    * This method can be called multiple times. All the passed payloads will be added in the execute
+    * reply message.
+    *
+    * @param payload
+    *   payload to add to the reply message, should be a stringifi-ed JSON object
+    */
+  def addPayload(payload: String): Unit
+
   def canOutput(): Boolean
 
   def messageIdOpt: Option[String]
@@ -83,6 +93,9 @@ object OutputHandler {
     def canOutput(): Boolean =
       false
 
+    def addPayload(payload: String): Unit =
+      unsupported()
+
     def messageIdOpt: Option[String] = None
   }
 
@@ -100,6 +113,9 @@ object OutputHandler {
 
     def messageIdOpt: Option[String] =
       underlying.messageIdOpt
+
+    def addPayload(payload: String): Unit =
+      underlying.addPayload(payload)
   }
 
   object NopOutputHandler extends OutputHandler {
@@ -110,6 +126,8 @@ object OutputHandler {
     def canOutput(): Boolean                          = false
 
     def messageIdOpt: Option[String] = None
+
+    def addPayload(payload: String): Unit = ()
   }
 
 }

--- a/modules/shared/protocol/src/main/scala/almond/protocol/Execute.scala
+++ b/modules/shared/protocol/src/main/scala/almond/protocol/Execute.scala
@@ -38,7 +38,7 @@ object Execute {
       def apply(
         execution_count: Int,
         user_expressions: Map[String, RawJson], // value type?
-        payload: List[RawJson] = List[RawJson]()
+        payload: List[RawJson]
       ): Success =
         Success(
           execution_count,
@@ -54,7 +54,9 @@ object Execute {
       traceback: List[String],
       status: String, // no default value here for the value not to be swallowed by the JSON encoder
       execution_count: Int =
-        -1 // required in some context (e.g. errored execute_reply from jupyter console)
+        -1, // required in some context (e.g. errored execute_reply from jupyter console)
+      // having this one here doesn't follow the Jupyter messaging specification
+      payload: List[RawJson]
     ) extends Reply {
       assert(status == "error")
     }
@@ -63,27 +65,31 @@ object Execute {
       def apply(
         ename: String,
         evalue: String,
-        traceback: List[String]
-      ): Error =
-        Error(
-          ename,
-          evalue,
-          traceback,
-          "error"
-        )
-
-      def apply(
-        ename: String,
-        evalue: String,
         traceback: List[String],
-        execution_count: Int
+        payload: List[RawJson]
       ): Error =
         Error(
           ename,
           evalue,
           traceback,
           "error",
-          execution_count
+          payload = payload
+        )
+
+      def apply(
+        ename: String,
+        evalue: String,
+        traceback: List[String],
+        execution_count: Int,
+        payload: List[RawJson]
+      ): Error =
+        Error(
+          ename,
+          evalue,
+          traceback,
+          "error",
+          execution_count,
+          payload = payload
         )
     }
 

--- a/modules/shared/test-kit/src/main/scala/almond/testkit/ClientStreams.scala
+++ b/modules/shared/test-kit/src/main/scala/almond/testkit/ClientStreams.scala
@@ -147,6 +147,8 @@ final case class ClientStreams(
       .collect {
         case s: Execute.Reply.Success if s.payload.nonEmpty =>
           s.execution_count -> s.payload
+        case err: Execute.Reply.Error if err.payload.nonEmpty =>
+          err.execution_count -> err.payload
       }
       .toMap
 

--- a/modules/shared/test/src/main/scala/almond/interpreter/TestOutputHandler.scala
+++ b/modules/shared/test/src/main/scala/almond/interpreter/TestOutputHandler.scala
@@ -37,6 +37,8 @@ final class TestOutputHandler extends OutputHandler {
     output.result()
 
   def messageIdOpt: Option[String] = None
+
+  def addPayload(payload: String): Unit = ()
 }
 
 object TestOutputHandler {


### PR DESCRIPTION
This allows users to add "payloads" to execute reply (both successful ones and errors), like
```scala
publish.addPayload("""{"source": "foo", "thing": 2}""")
```

`addPayload` expects a stringified JSON object. The payload is then assumed to be a JSON object, and written in the `payloads` field of [`execute_reply`](https://jupyter-client.readthedocs.io/en/5.2.3/messaging.html#execution-results) message. Note that unlike what the spec says, we also add the `payloads` field in errored `execute_reply`, like ipykernel apparently does.

---

Backport of https://github.com/almond-sh/almond/pull/1562