### PR TITLE
Only keep support for two Scala 3 versions: LTS and latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         OS: [ubuntu-latest]
-        SCALA: [2.12.20, 2.12.21, 2.13.17, 2.13.18, 3.3.7, 3.4.3, 3.5.2, 3.6.4, 3.7.3, 3.8.1]
+        SCALA: [2.12.20, 2.12.21, 2.13.17, 2.13.18, 3.3.7, 3.8.1]
         include:
           - OS: windows-latest
             SCALA: 2.13.18

--- a/build.mill
+++ b/build.mill
@@ -433,9 +433,9 @@ trait Launcher extends AlmondSimpleModule with BootstrapLauncher with PropertyFi
   private def sv   = ScalaVersions.scala3Latest
   def scalaVersion = sv
   def moduleDeps = Seq(
-    scala.`coursier-logger`(ScalaVersions.scala3Compat),
-    scala.`shared-directives`(ScalaVersions.scala3Compat),
-    shared.kernel(ScalaVersions.scala3Compat)
+    scala.`coursier-logger`(ScalaVersions.scala3Lts),
+    scala.`shared-directives`(ScalaVersions.scala3Lts),
+    shared.kernel(ScalaVersions.scala3Lts)
   )
   def mvnDeps = Seq(
     Deps.caseApp,

--- a/mill-build/src/almondbuild/ScalaVersions.scala
+++ b/mill-build/src/almondbuild/ScalaVersions.scala
@@ -2,27 +2,14 @@ package almondbuild
 
 object ScalaVersions {
   def scala3Latest   = "3.8.1"
-  def scala3Compat   = "3.3.4"
+  def scala3Lts      = "3.3.7"
   def scala213       = "2.13.18"
   def scala212       = "2.12.21"
-  val binaries       = Seq(scala3Compat, scala213, scala212)
+  val binaries       = Seq(scala3Lts, scala213, scala212)
   val scala2Binaries = Seq(scala213, scala212)
   val all = Seq(
     scala3Latest,
-    "3.8.0",
-    "3.7.3",
-    "3.6.4",
-    "3.6.3",
-    "3.6.2",
-    "3.5.2",
-    "3.5.1",
-    "3.5.0",
-    "3.4.3",
-    "3.4.2",
-    "3.3.7",
-    "3.3.6",
-    "3.3.5",
-    scala3Compat,
+    scala3Lts,
     scala213,
     "2.13.17",
     "2.13.16",
@@ -37,6 +24,6 @@ object ScalaVersions {
   def binary(sv: String) =
     if (sv.startsWith("2.12.")) scala212
     else if (sv.startsWith("2.13.")) scala213
-    else scala3Compat
+    else scala3Lts
 
 }


### PR DESCRIPTION
Support for many Scala 2 versions is useful when using Spark, where we want to use the exact same version as the Spark distribution. This isn't a problem in Scala 3, so we can just drop support for many of them.