### PR TITLE
Keep Scala 3 support only for latest, LTS, and latest 3.7.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         OS: [ubuntu-latest]
-        SCALA: [2.12.20, 2.12.21, 2.13.17, 2.13.18, 3.3.7, 3.4.3, 3.5.2, 3.6.4, 3.7.3, 3.8.1]
+        SCALA: [2.12.20, 2.12.21, 2.13.17, 2.13.18, 3.3.7, 3.7.3, 3.8.1]
         include:
           - OS: windows-latest
             SCALA: 2.13.18

--- a/build.mill
+++ b/build.mill
@@ -212,16 +212,8 @@ trait ScalaKernelApi extends Cross.Module[String] with AlmondModule with Depende
       "2.12.21" -> Version("0.14.5"),
       "2.13.17" -> Version("0.14.2"),
       "2.13.18" -> Version("0.14.5"),
-      "3.3.6"   -> Version("0.14.2"),
       "3.3.7"   -> Version("0.14.2"),
-      "3.4.2"   -> Version("0.14.2"),
-      "3.5.0"   -> Version("0.14.2"),
-      "3.5.1"   -> Version("0.14.2"),
-      "3.5.2"   -> Version("0.14.2"),
-      "3.6.2"   -> Version("0.14.2"),
-      "3.6.4"   -> Version("0.14.2"),
       "3.7.3"   -> Version("0.14.2"),
-      "3.8.0"   -> Version("0.14.5"),
       "3.8.1"   -> Version("0.14.5")
     )
     val base = super.mimaPreviousVersions()

--- a/mill-build/src/almondbuild/ScalaVersions.scala
+++ b/mill-build/src/almondbuild/ScalaVersions.scala
@@ -2,26 +2,14 @@ package almondbuild
 
 object ScalaVersions {
   def scala3Latest   = "3.8.1"
-  def scala3Compat   = "3.3.4"
+  def scala3Compat   = "3.3.7"
   def scala213       = "2.13.18"
   def scala212       = "2.12.21"
   val binaries       = Seq(scala3Compat, scala213, scala212)
   val scala2Binaries = Seq(scala213, scala212)
   val all = Seq(
     scala3Latest,
-    "3.8.0",
     "3.7.3",
-    "3.6.4",
-    "3.6.3",
-    "3.6.2",
-    "3.5.2",
-    "3.5.1",
-    "3.5.0",
-    "3.4.3",
-    "3.4.2",
-    "3.3.7",
-    "3.3.6",
-    "3.3.5",
     scala3Compat,
     scala213,
     "2.13.17",

--- a/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
+++ b/modules/scala/test-definitions/src/main/scala/almond/integration/Tests.scala
@@ -277,7 +277,7 @@ object Tests {
               |def thing(s: String) = ""; val res1_1 = thing(Array(2))
               |                                                   ^
               |Compilation Failed""".stripMargin
-          else if (scalaVersion.startsWith("3.3.") || scalaVersion.startsWith("3.4."))
+          else if (scalaVersion.startsWith("3.3."))
             """-- [E007] Type Mismatch Error: cmd1.sc:1:51 ------------------------------------
               |1 |def thing(s: String) = ""; val res1_1 = thing(Array(2))
               |  |                                              ^^^^^^^^
@@ -931,7 +931,7 @@ object Tests {
             |        ^
             |No warnings can be incurred under -Xfatal-warnings.
             |Compilation Failed""".stripMargin
-        else if ((0 to 3).exists(min => scalaVersion.startsWith(s"3.$min.")))
+        else if (scalaVersion.startsWith("3.3."))
           // FIXME The line number is wrong here
           """-- Error: cmd2.sc:3:8 ----------------------------------------------------------
             |3 |val n = getValue()


### PR DESCRIPTION
Keeping latest 3.7.x for now, that's the latest Scala 3 version with compatibility with 2.13.x