### PR TITLE
Inspect and kernel info fixes

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala-2/almond/internals/ScalaInterpreterInspections.scala
+++ b/modules/scala/scala-interpreter/src/main/scala-2/almond/internals/ScalaInterpreterInspections.scala
@@ -119,31 +119,54 @@ final class ScalaInterpreterInspections(
                   None
                 }
               )
-              .getOrElse(tree.toString)
+              // `tree.toString` used to be the fallback here, but printing a tree calls
+              // symName -> isErroneous -> Symbol.info, which is another off-PC-thread
+              // symbol read and trips assertCorrectThread. typeOfTree now produces this
+              // fallback from inside its own askForResponse block instead.
+              .getOrElse("<unknown>")
 
             val docstringsOpt = {
               val symbol = tree.symbol
               if (symbol == null)
                 None
               else {
-                val sym = {
-                  if (!symbol.isJava && symbol.isPrimaryConstructor) symbol.owner
-                  else symbol
-                }.toSemantic
+                // Both `.toSemantic` and `allOverriddenSymbols` read symbol infos, which
+                // the presentation compiler only allows from its own thread. Computing
+                // them here, and in particular handing Docstrings a thunk that it
+                // invokes later from parentDocumentation, trips
+                // Global.assertCorrectThread; that AssertionError is not NonFatal, so it
+                // terminates the kernel. Compute both on the PC thread instead, and pass
+                // a thunk that only returns the finished value.
+                val symbolInfo = pressy.askForResponse { () =>
+                  val s = {
+                    if (!symbol.isJava && symbol.isPrimaryConstructor) symbol.owner
+                    else symbol
+                  }.toSemantic
+                  (s, symbol.allOverriddenSymbols.map(_.toSemantic).toList.asJava)
+                }.get.swap.toOption
+
+                val (sym, parents) = symbolInfo.getOrElse(
+                  ("", java.util.Collections.emptyList[String]())
+                )
                 log.debug(s"Symbol for '${code.take(pos)}|${code.drop(pos)}' is $sym")
 
                 val documentation =
-                  try
-                    docs.documentation(
-                      sym,
-                      () => symbol.allOverriddenSymbols.map(_.toSemantic).toList.asJava,
-                      scala.meta.pc.ContentType.MARKDOWN
-                    )
-                  catch {
-                    case e: IndexingExceptions.InvalidSymbolException =>
-                      log.warn(s"Ignoring exception when trying to get scaladoc of $sym", e)
-                      Optional.empty[SymbolDocumentation]()
-                  }
+                  if (sym.isEmpty)
+                    Optional.empty[SymbolDocumentation]()
+                  else
+                    try
+                      docs.documentation(
+                        sym,
+                        () => parents,
+                        scala.meta.pc.ContentType.MARKDOWN
+                      )
+                    catch {
+                      // widened from InvalidSymbolException: a failed docstring lookup
+                      // should cost an inspection, not the whole kernel
+                      case e: Throwable =>
+                        log.warn(s"Ignoring exception when trying to get scaladoc of $sym", e)
+                        Optional.empty[SymbolDocumentation]()
+                    }
 
                 if (documentation.isPresent) {
                   val docstring = documentation.get().docstring
@@ -205,10 +228,16 @@ object ScalaInterpreterInspections {
       }
 
       stringOrTree match {
-        case Right(string)                    => Some(string)
-        case Left(null)                       => None
-        case Left(tree) if tree.tpe ne NoType => Some(tree.tpe.widen.toString)
-        case _                                => None
+        case Right(string) => Some(string)
+        case Left(null)    => None
+        // askTypeAt can hand back a tree that has not been typed yet while a background
+        // compile is in flight, so `tpe` needs a null check as well as the NoType one.
+        case Left(tree) if (tree.tpe ne null) && (tree.tpe ne NoType) =>
+          Some(tree.tpe.widen.toString)
+        // last resort: print the tree. This has to happen here, on the PC thread,
+        // because printing reads symbol infos (symName -> isErroneous -> Symbol.info).
+        case Left(tree) => Some(tree.toString)
+        case _          => None
       }
     }
 

--- a/modules/scala/scala-interpreter/src/main/scala-2/almond/internals/ScalaInterpreterInspections.scala
+++ b/modules/scala/scala-interpreter/src/main/scala-2/almond/internals/ScalaInterpreterInspections.scala
@@ -202,8 +202,14 @@ final class ScalaInterpreterInspections(
               docstringsOpt.fold[Frag](Seq.empty[Frag])(pre(_))
             )
 
+            val wholeText = typeStr + docstringsOpt.fold("")(newLine + newLine + _)
+
+            // A text/plain alternative alongside the HTML: the VS Code Jupyter PowerToys
+            // Contextual Help panel drops any inspect_request reply whose data has no
+            // text/plain key, and reports it to the user as "No response from kernel".
             val res = Inspection.fromDisplayData(
               DisplayData.html(wholeHtml.toString)
+                .add(DisplayData.ContentType.text, wholeText)
             )
 
             Some(res)

--- a/modules/shared/interpreter/src/main/scala/almond/interpreter/messagehandlers/InterpreterMessageHandlers.scala
+++ b/modules/shared/interpreter/src/main/scala/almond/interpreter/messagehandlers/InterpreterMessageHandlers.scala
@@ -165,6 +165,7 @@ final case class InterpreterMessageHandlers(
 
   def otherHandlers: MessageHandler =
     kernelInfoHandler.orElse(
+      kernelInfoControlHandler,
       completeHandler,
       interruptHandler,
       shutdownHandler,
@@ -229,6 +230,22 @@ final case class InterpreterMessageHandlers(
           .reply(KernelInfo.replyType, info)
           .enqueueOn(Channel.Requests, queue)
       } yield ()
+    }
+
+  // Protocol 5.5 added kernel_info_request on the control channel ("This is the same kernel
+  // info message as that received on the Shell channel"), and the VS Code Jupyter extension
+  // sends it there. Answered off the execute queue, without the busy/idle status publication
+  // of kernelInfoHandler, so that it is still answered while a cell is running.
+  def kernelInfoControlHandler: MessageHandler =
+    MessageHandler(
+      Channel.Control,
+      MessageType[Unit](KernelInfo.requestType.messageType)
+    ) { message =>
+      Stream.eval(interpreter.kernelInfo).flatMap { info =>
+        message
+          .reply(KernelInfo.replyType, info)
+          .streamOn(Channel.Control)
+      }
     }
 
   def shutdownHandler: MessageHandler =


### PR DESCRIPTION
Hello. I am not an experienced Scala developer and I relied on Claude for this bug fix. I understand that maintainers may be distrustful of AI code, however, I do think the bug is serious and impactful enough to users that a vibecoded PR is better than nothing. I am happy to take criticism and fix problems that are pointed out by maintainers.

Commit 1 : fix fatal error with `inspect`

My understanding is that Scala 2's internal presentation compiler has a rule that symbol information can only be read from the compiler's own thread, it enforces this with `assertCorrectThread`. almond's `inspect` did several such reads from whatever thread the inspect request arrived on: `symbol.toSemantic`, `symbol.allOverriddenSymbols`, and the `tree.toString` fallback. `inspect` then passes to Metals' Docstring a lazy thunk which Docstring invokes from `parentDocumentation`, which is off-thread.

The proposed fix is to compute the results eagerly in the correct thread and then embed the results in a thunk, which can be safely evaluated in another thread. 

The PR also widens one catch from InvalidSymbolException to Throwable, so a failed scaladoc lookup is not fatal.

Commit 2: Improve usability in VSCode
VSCode has a [Jupyter extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) that allows the user to render and run Jupyter notebooks. The [VSCode Jupyter Powertoys extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.vscode-jupyter-powertoys) allows the user to access the Contextual Help panel. However, the Powertoys extension checks for 'text/plain' in the `content.data` field of the MIME bundle, and if this is absent, it renders the string "No response from kernel". This is not a bug in almond but it seems easier to fix it on the Almond side, as the Powertoys extension has not been updated in two years.

The other change this commit makes is to make Almond register a handler that listens on the `control` ZeroMQ socket. Since protocol 5.3 of the Jupyter Messaging Protocol, the spec says `kernel_info_request` may be sent on either shell or control.
The new handler skips almond's blocking helper. it publishes no busy/idle status.