### PR TITLE
Use coursier main module less

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -211,8 +211,10 @@ trait ScalaInterpreter extends Cross.Module[String] with AlmondModule {
       else
         Seq.empty
     metabrowse ++ Seq(
+      // only for coursier.util.ModuleMatcher, to match automatic dependencies with globs
       Deps.coursier.withDottyCompat(crossScalaVersion),
       Deps.coursierApi,
+      Deps.coursierPaths,
       Deps.dependencyInterface,
       Deps.directiveHandler,
       Deps.jansi,

--- a/build.mill
+++ b/build.mill
@@ -266,6 +266,9 @@ trait ScalaKernel extends Cross.Module[String] with AlmondModule with ExternalSo
   def mvnDeps = Seq(
     Deps.caseApp,
     Deps.classPathUtil,
+    Deps.coursierApi,
+    Deps.dependency,
+    Deps.dependencyInterface,
     Deps.scalafmtDynamic.withDottyCompat(crossScalaVersion)
   )
   object test extends Cross[ScalaKernelTests](ScalaVersions.fullVersionsFor(crossValue))

--- a/mill-build/src/almondbuild/Deps.scala
+++ b/mill-build/src/almondbuild/Deps.scala
@@ -45,6 +45,7 @@ object Deps {
   def csVersion           = Versions.coursier
   def coursierApi         = mvn"io.get-coursier:interface:1.0.29-M4"
   def coursierLauncher    = mvn"io.get-coursier:coursier-launcher_2.13:${Versions.coursier}"
+  def coursierPaths       = mvn"io.get-coursier:coursier-paths:${Versions.coursier}"
   def coursierVersions    = mvn"io.get-coursier::versions:0.5.3"
   def dependencyInterface = mvn"io.get-coursier::dependency-interface:0.3.2"
   def directiveHandler    = mvn"io.github.alexarchambault.scala-cli::directive-handler:0.1.4"

--- a/mill-build/src/almondbuild/Deps.scala
+++ b/mill-build/src/almondbuild/Deps.scala
@@ -47,6 +47,7 @@ object Deps {
   def coursierLauncher    = mvn"io.get-coursier:coursier-launcher_2.13:${Versions.coursier}"
   def coursierPaths       = mvn"io.get-coursier:coursier-paths:${Versions.coursier}"
   def coursierVersions    = mvn"io.get-coursier::versions:0.5.3"
+  def dependency          = mvn"io.get-coursier::dependency:0.3.2"
   def dependencyInterface = mvn"io.get-coursier::dependency-interface:0.3.2"
   def directiveHandler    = mvn"io.github.alexarchambault.scala-cli::directive-handler:0.1.4"
   def expecty             = mvn"com.eed3si9n.expecty::expecty:0.17.1"

--- a/modules/scala/scala-interpreter/src/main/scala/almond/amm/AmmInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/amm/AmmInterpreter.scala
@@ -255,7 +255,7 @@ object AmmInterpreter {
       }
 
       // TODO: remove jitpack once jvm-repr is published to central
-      val allExtraRepos = extraRepos ++ Seq(coursier.Repositories.jitpack.root)
+      val allExtraRepos = extraRepos ++ Seq("https://jitpack.io")
       ammInterp0.repositories() = ammInterp0.repositories() ++
         allExtraRepos.map { r =>
           if (r.startsWith("ivy:"))

--- a/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
+++ b/modules/scala/scala-kernel/src/main/scala/almond/Options.scala
@@ -14,11 +14,12 @@ import caseapp.core.Scala3Helpers._
 import caseapp.core.help.Help
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromArray
 import coursierapi.{Dependency, Module}
-import coursier.parse.{DependencyParser, ModuleParser}
+import dependency.ScalaParameters
+import dependency.api.ops._
+import dependency.parser.{DependencyParser, ModuleParser}
 
 import scala.collection.compat._
 import scala.concurrent.duration.{Duration, DurationInt}
-import scala.jdk.CollectionConverters._
 
 // format: off
 @ProgName("almond")
@@ -164,6 +165,17 @@ final case class Options(
       sv.split('.').head
   }
 
+  private lazy val scalaParams =
+    ScalaParameters(scala.util.Properties.versionNumberString)
+
+  /** The configuration of an inline-configuration dependency (like `org:name:version:config`).
+    *
+    * `toCs` doesn't carry it over to the coursier-interface dependency, so we read it from the user
+    * params the parser puts it in, and apply it ourselves.
+    */
+  private def inlineConfiguration(dep: dependency.AnyDependency): Option[String] =
+    dep.userParamsMap.get("$inlineConfiguration").flatMap(_.flatten.headOption)
+
   private lazy val ammSparkVersion = defaultAlmondSparkVersion
     .map(_.trim)
     .filter(_.nonEmpty)
@@ -200,26 +212,19 @@ final case class Options(
       .map { s =>
         s.split("=>") match {
           case Array(trigger, auto) =>
-            val trigger0 = ModuleParser.javaOrScalaModule(trigger) match {
+            val trigger0 = ModuleParser.parse(trigger) match {
               case Left(err) =>
                 sys.error(s"Malformed module '$trigger' in --auto-dependency argument '$s': $err")
               case Right(m) =>
-                val mod0 = m.module(scala.util.Properties.versionNumberString)
-                Module.of(mod0.organization.value, mod0.name.value, mod0.attributes.asJava)
+                m.applyParams(scalaParams).toCs
             }
-            val auto0 = DependencyParser.javaOrScalaDependencyParams(auto) match {
+            val auto0 = DependencyParser.parse(auto) match {
               case Left(err) =>
                 sys.error(s"Malformed dependency '$auto' in --auto-dependency argument '$s': $err")
-              case Right((d, _)) =>
-                val dep = d.dependency(scala.util.Properties.versionNumberString)
-                Dependency.of(
-                  dep.module.organization.value,
-                  dep.module.name.value,
-                  dep.versionConstraint.asString
-                )
-                  .withConfiguration(dep.configuration.value)
-                  .withClassifier(dep.attributes.classifier.value)
-                  .withType(dep.attributes.`type`.value)
+              case Right(d) =>
+                val dep0 = d.applyParams(scalaParams)
+                val dep  = dep0.toCs
+                inlineConfiguration(dep0).fold(dep)(dep.withConfiguration)
             }
             trigger0 -> auto0
           case _ =>
@@ -256,12 +261,11 @@ final case class Options(
         else {
           val before = s.substring(0, idx)
           val ver    = s.substring(idx + 1)
-          val mod = ModuleParser.javaOrScalaModule(before) match {
+          val mod = ModuleParser.parse(before) match {
             case Left(err) =>
               sys.error(s"Malformed module '$before' in --auto-version argument '$s': $err")
             case Right(m) =>
-              val mod0 = m.module(scala.util.Properties.versionNumberString)
-              Module.of(mod0.organization.value, mod0.name.value, mod0.attributes.asJava)
+              m.applyParams(scalaParams).toCs
           }
 
           mod -> ver


### PR DESCRIPTION
Favor newer and more stable helper coursier modules instead. The main coursier modules shouldn't be published for Scala 2.12 anymore, but we still want to support Scala 2.12 here, so we should switch off from it.